### PR TITLE
capture-poll: fix GOOGLE_SA_KEY padding error

### DIFF
--- a/scripts/capture/scheduled_capture_poll.py
+++ b/scripts/capture/scheduled_capture_poll.py
@@ -60,7 +60,8 @@ def _sheets():
     if not sa_b64:
         print("ERROR: GOOGLE_SA_KEY not set")
         sys.exit(1)
-    info = json.loads(base64.b64decode(sa_b64))
+    # GitHub Secrets strips trailing '=' padding; add it back before decoding
+    info = json.loads(base64.b64decode(sa_b64.strip() + "=="))
     creds = Credentials.from_service_account_info(
         info, scopes=["https://www.googleapis.com/auth/spreadsheets"]
     )


### PR DESCRIPTION
Test run #24471552107 failed with `binascii.Error: Incorrect padding` on the SA key decode. Matches the padding fix already present in capture_pipeline.py — GitHub Secrets strips trailing `=`, so append `==` before b64decode.

## Test plan
- [ ] Merge
- [ ] Re-run Scheduled Capture Poll manually with max_dispatch=1
- [ ] Confirm the poller reads the sheet successfully