### PR TITLE
Add /series dispatcher: gcal + inbox + 4am queue in one shot

### DIFF
--- a/.github/workflows/capture_dispatcher.yml
+++ b/.github/workflows/capture_dispatcher.yml
@@ -1,12 +1,15 @@
 name: Capture Dispatcher (issue-comment)
 
-# Lets Claude (or anyone with repo-owner login) fire the capture pipeline by
-# posting a GitHub issue/PR comment like:
-#   /capture https://www.instagram.com/reel/XXXX/ sovereign
-#   /capture https://youtu.be/XXXX book --credits --story-id BCI-042
+# Lets Claude (or anyone with repo-owner login) fire workflows by posting
+# GitHub issue/PR comments. Supported commands:
 #
-# Projects: sovereign (Brazil/USA news, political) | book (fact-check) | content (OPC/UGC)
-# Defaults: project=content, credits=false
+#   /capture <url> [sovereign|book|content] [--credits] [--story-id X] [--notes ...]
+#     Fires capture_pipeline.yml
+#
+#   /series <name> | <description> | [niche] | [YYYY-MM-DD]
+#     Fires series_init.yml (writes to 📥 Inbox + Flow Plans Tracker + Calendar)
+#
+# Gated to repo owner to protect API spend.
 
 on:
   issue_comment:
@@ -21,13 +24,27 @@ permissions:
 jobs:
   dispatch:
     if: >-
-      startsWith(github.event.comment.body, '/capture') &&
+      (startsWith(github.event.comment.body, '/capture') ||
+       startsWith(github.event.comment.body, '/series')) &&
       github.event.comment.user.login == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Detect command
+        id: cmd
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          if printf '%s' "$BODY" | head -n 1 | grep -q '^/series'; then
+            echo "command=series" >> "$GITHUB_OUTPUT"
+          else
+            echo "command=capture" >> "$GITHUB_OUTPUT"
+          fi
+
+
       - name: Parse /capture command
         id: parse
+        if: steps.cmd.outputs.command == 'capture'
         env:
           BODY: ${{ github.event.comment.body }}
         run: |
@@ -50,7 +67,7 @@ jobs:
           echo "Parsed: url=$URL project=$PROJECT credits=$CREDITS story_id=$STORY_ID"
 
       - name: Reject if no URL
-        if: steps.parse.outputs.url == ''
+        if: steps.cmd.outputs.command == 'capture' && steps.parse.outputs.url == ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -62,7 +79,7 @@ jobs:
             });
 
       - name: Dispatch capture_pipeline.yml
-        if: steps.parse.outputs.url != ''
+        if: steps.cmd.outputs.command == 'capture' && steps.parse.outputs.url != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           URL: ${{ steps.parse.outputs.url }}
@@ -81,7 +98,7 @@ jobs:
             -f notes="$NOTES"
 
       - name: Acknowledge on the comment thread
-        if: steps.parse.outputs.url != ''
+        if: steps.cmd.outputs.command == 'capture' && steps.parse.outputs.url != ''
         uses: actions/github-script@v7
         env:
           URL: ${{ steps.parse.outputs.url }}
@@ -98,4 +115,78 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `Capture dispatched\n- project: **${project}**\n- credits: ${credits}\n- url: ${url}\n\nRun: ${actionsUrl}`
+            });
+
+      # ─── /series command ─────────────────────────────────────────────
+      - name: Parse /series command
+        id: parse_series
+        if: steps.cmd.outputs.command == 'series'
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # Format: /series <name> | <description> | [niche] | [YYYY-MM-DD]
+          LINE=$(printf '%s' "$BODY" | head -n 1 | sed 's|^/series[[:space:]]*||')
+          IFS='|' read -r NAME DESC NICHE DATE <<EOF
+          $LINE
+          EOF
+          NAME=$(echo "$NAME" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          DESC=$(echo "$DESC" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          NICHE=$(echo "$NICHE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          DATE=$(echo "$DATE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          NICHE=${NICHE:-Mixed}
+          {
+            echo "name=$NAME"
+            echo "description=$DESC"
+            echo "niche=$NICHE"
+            echo "review_date=$DATE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Parsed series: name=$NAME niche=$NICHE date=$DATE"
+
+      - name: Reject if series missing name or description
+        if: steps.cmd.outputs.command == 'series' && (steps.parse_series.outputs.name == '' || steps.parse_series.outputs.description == '')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "`/series` needs a name AND description.\n\nUsage: `/series <name> | <description> | [niche] | [YYYY-MM-DD]`"
+            });
+
+      - name: Dispatch series_init.yml
+        if: steps.cmd.outputs.command == 'series' && steps.parse_series.outputs.name != '' && steps.parse_series.outputs.description != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          S_NAME:  ${{ steps.parse_series.outputs.name }}
+          S_DESC:  ${{ steps.parse_series.outputs.description }}
+          S_NICHE: ${{ steps.parse_series.outputs.niche }}
+          S_DATE:  ${{ steps.parse_series.outputs.review_date }}
+        run: |
+          gh workflow run series_init.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f name="$S_NAME" \
+            -f description="$S_DESC" \
+            -f niche="$S_NICHE" \
+            -f review_date="$S_DATE"
+
+      - name: Acknowledge series dispatch
+        if: steps.cmd.outputs.command == 'series' && steps.parse_series.outputs.name != '' && steps.parse_series.outputs.description != ''
+        uses: actions/github-script@v7
+        env:
+          S_NAME:  ${{ steps.parse_series.outputs.name }}
+          S_NICHE: ${{ steps.parse_series.outputs.niche }}
+          S_DATE:  ${{ steps.parse_series.outputs.review_date }}
+        with:
+          script: |
+            const name  = process.env.S_NAME;
+            const niche = process.env.S_NICHE;
+            const date  = process.env.S_DATE || '(tomorrow)';
+            const actionsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/series_init.yml`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Series dispatched\n- name: **${name}**\n- niche: ${niche}\n- review: ${date}\n\nWriting to 📥 Inbox + Flow Plans Tracker + Calendar.\nRun: ${actionsUrl}`
             });

--- a/.github/workflows/series_init.yml
+++ b/.github/workflows/series_init.yml
@@ -1,0 +1,125 @@
+name: Series Init — gcal + inbox + 4am queue
+
+# Bootstraps a new content series in one shot:
+#   1) Appends a row to 📥 Inbox tab (Ideas & Inbox spreadsheet)
+#   2) Appends a row to Flow Plans Tracker → All Docs (so the 4AM agent picks it up)
+#   3) Creates a Google Calendar review event (default: tomorrow 10–11 AM ET)
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Series name'
+        required: true
+      description:
+        description: 'Series description (one-liner)'
+        required: true
+      niche:
+        description: 'Niche tag (e.g. "USA News", "Brazil News", "OPC")'
+        required: false
+        default: 'Mixed'
+      review_date:
+        description: 'Calendar review date YYYY-MM-DD (blank = tomorrow)'
+        required: false
+        default: ''
+      review_start:
+        description: 'Calendar start HH:MM ET'
+        required: false
+        default: '10:00'
+      review_end:
+        description: 'Calendar end HH:MM ET'
+        required: false
+        default: '11:00'
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Write to Inbox, Flow Plans Tracker, and Calendar
+        env:
+          SHEETS_TOKEN:     ${{ secrets.SHEETS_TOKEN }}
+          SERIES_NAME:      ${{ inputs.name }}
+          SERIES_DESC:      ${{ inputs.description }}
+          SERIES_NICHE:     ${{ inputs.niche }}
+          REVIEW_DATE:      ${{ inputs.review_date }}
+          REVIEW_START:     ${{ inputs.review_start }}
+          REVIEW_END:       ${{ inputs.review_end }}
+        run: |
+          pip install -q google-auth google-auth-httplib2 google-api-python-client
+          python3 <<'PYEOF'
+          import os, json
+          from datetime import datetime, timedelta, timezone
+          from google.oauth2.credentials import Credentials
+          from google.auth.transport.requests import Request
+          from googleapiclient.discovery import build
+
+          td = json.loads(os.environ['SHEETS_TOKEN'])
+          creds = Credentials(
+              token=td.get('token'),
+              refresh_token=td.get('refresh_token'),
+              token_uri=td.get('token_uri', 'https://oauth2.googleapis.com/token'),
+              client_id=td.get('client_id'),
+              client_secret=td.get('client_secret'),
+              scopes=td.get('scopes', [])
+          )
+          if creds.expired and creds.refresh_token:
+              creds.refresh(Request())
+
+          sheets = build('sheets', 'v4', credentials=creds)
+
+          name  = os.environ['SERIES_NAME']
+          desc  = os.environ['SERIES_DESC']
+          niche = os.environ['SERIES_NICHE']
+          now_utc = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%MZ')
+
+          # ─── 1. 📥 Inbox tab ────────────────────────────────────────
+          IDEAS_INBOX_ID = '1IrFrCNGVIF7cvAr9cIuAXvCtUR_-eQN1mdCpHXpfbcU'
+          try:
+              sheets.spreadsheets().values().append(
+                  spreadsheetId=IDEAS_INBOX_ID,
+                  range="'📥 Inbox'!A:C",
+                  valueInputOption='USER_ENTERED',
+                  insertDataOption='INSERT_ROWS',
+                  body={'values': [[now_utc, f"SERIES: {name} — {desc} (niche: {niche})", 'new']]}
+              ).execute()
+              print(f"✅ Inbox: appended series row")
+          except Exception as e:
+              print(f"⚠️ Inbox append failed: {e}")
+
+          # ─── 2. Flow Plans Tracker → All Docs ───────────────────────
+          FLOW_ID = '1fggy918FgPfnMQ-dzGQk2zx9uhi2_-uWXMKGW4MA47k'
+          try:
+              sheets.spreadsheets().values().append(
+                  spreadsheetId=FLOW_ID,
+                  range="'All Docs'!A:I",
+                  valueInputOption='USER_ENTERED',
+                  insertDataOption='INSERT_ROWS',
+                  body={'values': [[name, 'Series', niche, 'active', desc, '', '', '', now_utc]]}
+              ).execute()
+              print(f"✅ Flow Plans Tracker: appended series row")
+          except Exception as e:
+              print(f"⚠️ Flow Plans append failed: {e}")
+
+          # ─── 3. Google Calendar review event ────────────────────────
+          review = os.environ.get('REVIEW_DATE', '').strip()
+          if not review:
+              # tomorrow ET
+              review = (datetime.now(timezone.utc) + timedelta(days=1)).strftime('%Y-%m-%d')
+          start_t = os.environ.get('REVIEW_START', '10:00').strip() or '10:00'
+          end_t   = os.environ.get('REVIEW_END',   '11:00').strip() or '11:00'
+
+          try:
+              cal = build('calendar', 'v3', credentials=creds)
+              ev = {
+                  'summary': f"Series review: {name}",
+                  'description': f"{desc}\n\nNiche: {niche}\nQueued: {now_utc}\n\n4AM agent will surface this from the Flow Plans Tracker.",
+                  'start': {'dateTime': f"{review}T{start_t}:00", 'timeZone': 'America/New_York'},
+                  'end':   {'dateTime': f"{review}T{end_t}:00",   'timeZone': 'America/New_York'},
+                  'reminders': {'useDefault': False, 'overrides': [{'method': 'popup', 'minutes': 30}]}
+              }
+              result = cal.events().insert(calendarId='primary', body=ev).execute()
+              print(f"✅ Calendar: {result.get('htmlLink')}")
+          except Exception as e:
+              print(f"⚠️ Calendar insert failed: {e}")
+          PYEOF


### PR DESCRIPTION
## Summary
- `/series <name> | <desc> | [niche] | [YYYY-MM-DD]` on any issue/PR comment now fires `series_init.yml`
- `series_init.yml` writes to **📥 Inbox** + **Flow Plans Tracker** + creates a **Calendar review event** in one shot
- Same owner-gated pattern as `/capture`

## Test plan
- [x] YAML committed
- [ ] Merge → fire `/series` for "Lobby Money Tracker"

https://claude.ai/code/session_01PGmsU8AgB2xNv8HEo1Ckjg