### PR TITLE
Fix news niche routing + visual coverage + OPC cover artifact

### DIFF
--- a/scripts/content_creator/carousel_builder.py
+++ b/scripts/content_creator/carousel_builder.py
@@ -487,6 +487,7 @@ subject_type guide:
 
 VISUAL-EVERY-OTHER-SLIDE RULE (non-negotiable):
 Between cover and sources, never output "visual_hint": "none" on more than 1 consecutive slide.
+Also target at least 3 middle slides with visual_hint="context-image" plus specific queries.
 visual_hint values:
   "bio-card" → slide has named person in mentioned_people (face cards render automatically from that field)
   "context-image" → slide references a specific institution, building, place, event, or document; fill context_image_query with a specific search term (e.g. "Câmara dos Deputados Brasília", "Viktor Orbán 2026", "Supremo Tribunal Federal fachada", "Congresso Nacional aerial")
@@ -1308,17 +1309,6 @@ def _build_opc_html(content, slug, work_dir, media_paths=None):
   <div class="tag">Tip of the Week · Oak Park Construction</div>
   <div class="headline">{hl_html}</div>
   <div class="body-text">{content["subhead"]}</div>
-  <div class="sticker-stamp">▸ TIP</div>
-  <div class="sticker-slot">
-    <svg class="worker-silhouette" viewBox="0 0 200 260" xmlns="http://www.w3.org/2000/svg">
-      <path d="M100 50 C65 50 50 30 50 20 C50 15 55 12 100 12 C145 12 150 15 150 20 C150 30 135 50 100 50 Z" fill="currentColor" opacity="0.9"/>
-      <rect x="45" y="48" width="110" height="12" fill="currentColor" opacity="0.95"/>
-      <ellipse cx="100" cy="90" rx="32" ry="38" fill="currentColor"/>
-      <path d="M60 140 C60 120 75 110 100 110 C125 110 140 120 140 140 L140 260 L60 260 Z" fill="currentColor"/>
-      <rect x="92" y="150" width="16" height="40" fill="#0A0A0A" opacity="0.3"/>
-    </svg>
-    <div class="sticker-placeholder">ON-SITE · SWAP-IN</div>
-  </div>
   <div class="arrow">SWIPE →</div>
   <div class="slide-logo">Oak Park · CBC1263425</div>
 </div>
@@ -1784,6 +1774,14 @@ def visual_audit(content, niche):
     for i, s in enumerate(slides, start=2):
         if s.get("visual_hint") == "context-image" and not s.get("context_image_query", "").strip():
             issues.append(f"Slide {i}: visual_hint=context-image but context_image_query is empty.")
+
+    # News visual floor: require at least 3 middle slides with context-image.
+    if niche in ("brazil", "usa"):
+        context_count = sum(1 for s in slides if s.get("visual_hint") == "context-image")
+        if context_count < 3:
+            issues.append(
+                f"News visual floor miss: only {context_count} context-image slide(s); require >= 3."
+            )
 
     # Cover visual missing
     if not content.get("cover_visual"):

--- a/scripts/content_creator/main.py
+++ b/scripts/content_creator/main.py
@@ -103,6 +103,24 @@ def _safe_float(val, default=0.0):
         return default
 
 
+def _normalize_niche(raw_niche, fmt=""):
+    """Normalize source/format labels to opc|brazil|usa."""
+    n = (raw_niche or "").strip().lower()
+    f = (fmt or "").strip().lower()
+    if n in ("opc", "oak park", "oak park construction", "content"):
+        return "opc"
+    if n in ("usa", "us", "united states", "news-usa", "news-us", "america"):
+        return "usa"
+    if n in ("brazil", "brasil", "news", "news-brazil", "sovereign"):
+        return "brazil"
+    # Legacy fallback when Source is blank/noisy
+    if "usa" in f or "the chain" in f:
+        return "usa"
+    if "brazil" in f or "quem" in f or "verificamos" in f:
+        return "brazil"
+    return "opc"
+
+
 def _col_letter(n):
     r = ""
     while n > 0:
@@ -195,9 +213,7 @@ def get_approved_queue_rows():
             continue
         if v(row, "drive folder path"):
             continue  # already built
-        niche = v(row, "source").lower() or ("opc" if "opc" in v(row, "format").lower() else "brazil")
-        if niche not in ("opc", "brazil"):
-            niche = "brazil" if "quem" in v(row, "format").lower() else "opc"
+        niche = _normalize_niche(v(row, "source"), v(row, "format"))
         approved.append({
             "queue_row_idx": idx,
             "topic": v(row, "project name"),
@@ -210,6 +226,63 @@ def get_approved_queue_rows():
             "fake_news_confidence": _safe_float(v(row, "fake_news_confidence"), 0.0),
         })
     return approved
+
+
+def _default_context_query(slide, topic, niche):
+    """Safe fallback query for context-image slots."""
+    h_pt = (slide.get("heading_pt") or "").strip()
+    h_en = (slide.get("heading_en") or "").strip()
+    base = h_pt or h_en or topic
+    suffix = "Brasil política" if niche == "brazil" else "US politics"
+    return f"{base} {suffix}".strip()
+
+
+def _enforce_news_visual_targets(content, topic, niche):
+    """Guarantee at least 3 middle slides can render real context images."""
+    if not isinstance(content, dict):
+        return content
+    slides = content.get("slides", [])
+    if not isinstance(slides, list) or not slides:
+        return content
+
+    # Fill missing query where visual_hint is already context-image
+    for slide in slides:
+        if slide.get("visual_hint") == "context-image" and not (slide.get("context_image_query") or "").strip():
+            slide["context_image_query"] = _default_context_query(slide, topic, niche)
+
+    def _ready(s):
+        return s.get("visual_hint") == "context-image" and bool((s.get("context_image_query") or "").strip())
+
+    ready = sum(1 for s in slides if _ready(s))
+    needed = max(0, 3 - ready)
+    if needed <= 0:
+        return content
+
+    # Prefer non-profile slides first
+    for slide in slides:
+        if needed <= 0:
+            break
+        if _ready(slide):
+            continue
+        if slide.get("type") == "profile":
+            continue
+        slide["visual_hint"] = "context-image"
+        if not (slide.get("context_image_query") or "").strip():
+            slide["context_image_query"] = _default_context_query(slide, topic, niche)
+        needed -= 1
+
+    # Last resort: allow profile slides too
+    if needed > 0:
+        for slide in slides:
+            if needed <= 0:
+                break
+            if _ready(slide):
+                continue
+            slide["visual_hint"] = "context-image"
+            slide["context_image_query"] = _default_context_query(slide, topic, niche)
+            needed -= 1
+
+    return content
 
 
 def get_drive_service():
@@ -696,6 +769,9 @@ def process_one_topic(topic_entry, run_date, drive):
         print("  FAILED: content generation")
         return None
 
+    if niche in ("brazil", "usa"):
+        content = _enforce_news_visual_targets(content, topic, niche)
+
     # 1b. Visual audit — flag boring/incomplete carousels before rendering
     _, audit_issues, audit_summary = visual_audit(content, niche)
     print(f"  {audit_summary}")
@@ -1028,7 +1104,26 @@ def main():
     # Scored but un-approved rows → CQ Status=Draft (you flip to Approved in sheet to release)
     print("\n--- Phase A: Promoting Inspiration → Content Queue ---")
     try:
-        pick_topics(count_opc=2, count_brazil=1, count_usa=1)
+        picks = pick_topics(count_opc=2, count_brazil=1, count_usa=1)
+        pick_counts = {"opc": 0, "brazil": 0, "usa": 0}
+        for p in picks or []:
+            n = (p.get("niche") or "").lower()
+            if n in pick_counts:
+                pick_counts[n] += 1
+        shortfall = []
+        if pick_counts["brazil"] < 1:
+            shortfall.append("brazil<1")
+        if pick_counts["usa"] < 1:
+            shortfall.append("usa<1")
+        if shortfall:
+            msg = (
+                "Niche shortfall during topic promotion: "
+                + ", ".join(shortfall)
+                + f" | picks={pick_counts}. "
+                "Pipeline may overfill OPC unless Brazil/USA topics are approved and eligible."
+            )
+            print(f"  WARNING: {msg}")
+            _send_alert(msg)
     except Exception as e:
         print(f"  Topic picker failed: {e}")
         _send_alert(f"Topic picker crashed: {e}")
@@ -1041,6 +1136,17 @@ def main():
         _send_alert("No Approved rows in Content Queue — pipeline picked zero topics to build. Check Inspiration Library scoring + Queue status flips.")
         return
     print(f"  Found {len(approved)} Approved carousel(s) to build")
+    approved_counts = {"opc": 0, "brazil": 0, "usa": 0}
+    for a in approved:
+        n = (a.get("niche") or "").lower()
+        if n in approved_counts:
+            approved_counts[n] += 1
+    if approved_counts["brazil"] == 0 or approved_counts["usa"] == 0:
+        _send_alert(
+            "Approved queue niche gap: "
+            f"opc={approved_counts['opc']}, brazil={approved_counts['brazil']}, usa={approved_counts['usa']}. "
+            "No auto-build for missing niche in this run."
+        )
 
     drive = get_drive_service()
     results = []


### PR DESCRIPTION
## Summary
- fix niche normalization so USA routes correctly through queue promotion and processing
- enforce news visual target so Brazil and USA carousels generate richer context-image slides
- remove hardcoded OPC yellow placeholder sticker from cover layout
- add alerts for Brazil and USA shortfall in picks/approved queue

## Changed files
- scripts/content_creator/main.py
- scripts/content_creator/carousel_builder.py

## Validation
- AST parse checks passed for both modified files

## Why
This addresses the reported gaps: no USA output, weak image coverage outside cover, and the persistent yellow corner artifact on OPC covers.
