### PR TITLE
feat: wire Build Tracker to 9 remaining workflows (17/17 complete)

### DIFF
--- a/.github/workflows/blog-generator.yml
+++ b/.github/workflows/blog-generator.yml
@@ -91,3 +91,13 @@ jobs:
             });
         env:
           WP_URL: ${{ secrets.WP_URL }}
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow blog-generator.yml \
+            --status "${{ job.status }}"

--- a/.github/workflows/daily-content-processor.yml
+++ b/.github/workflows/daily-content-processor.yml
@@ -39,3 +39,13 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python scripts/daily_content_processor.py
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow daily-content-processor.yml \
+            --status "${{ job.status }}"

--- a/.github/workflows/generate-carousel-content.yml
+++ b/.github/workflows/generate-carousel-content.yml
@@ -77,3 +77,13 @@ jobs:
           echo "**Hook style:** ${{ inputs.hook_style }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Next step:** Add photo filename to column D in Content Queue, then run build-carousels.yml" >> $GITHUB_STEP_SUMMARY
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow generate-carousel-content.yml \
+            --status "${{ job.status }}"

--- a/.github/workflows/inspiration-scraper.yml
+++ b/.github/workflows/inspiration-scraper.yml
@@ -36,3 +36,13 @@ jobs:
           APIFY_API_KEY: ${{ secrets.APIFY_API_KEY }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
         run: python scripts/inspiration_scraper_cloud.py
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow inspiration-scraper.yml \
+            --status "${{ job.status }}"

--- a/.github/workflows/process-approved.yml
+++ b/.github/workflows/process-approved.yml
@@ -29,3 +29,13 @@ jobs:
           SHEETS_TOKEN_PATH: /tmp/oak_park_creds/sheets_token.json
           SHEET_ID: ${{ secrets.CONTENT_SHEET_ID }}
         run: python scripts/process_approved_cloud.py
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow process-approved.yml \
+            --status "${{ job.status }}"

--- a/.github/workflows/render-video.yml
+++ b/.github/workflows/render-video.yml
@@ -265,3 +265,13 @@ jobs:
             /tmp/${{ github.event.inputs.story_id }}_vo_en.mp3
             /tmp/${{ github.event.inputs.story_id }}_vo_pt.mp3
           retention-days: 30
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow render-video.yml \
+            --status "${{ job.status }}"

--- a/.github/workflows/schedule-posts.yml
+++ b/.github/workflows/schedule-posts.yml
@@ -28,3 +28,13 @@ jobs:
           CONTENT_SHEET_ID:  ${{ secrets.CONTENT_SHEET_ID }}
           BUFFER_API_KEY:    ${{ secrets.BUFFER_API_KEY_EXP04092027 }}
         run: python scripts/schedule_posts.py
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow schedule-posts.yml \
+            --status "${{ job.status }}"

--- a/.github/workflows/stocks_pipeline.yml
+++ b/.github/workflows/stocks_pipeline.yml
@@ -76,3 +76,13 @@ jobs:
             stocks/original/
             stocks/transcription/
           retention-days: 90
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow stocks_pipeline.yml \
+            --status "${{ job.status }}"

--- a/.github/workflows/topic_scraper.yml
+++ b/.github/workflows/topic_scraper.yml
@@ -112,3 +112,13 @@ jobs:
           name: "topic-cluster-${{ inputs.topic_cluster_id || github.run_id }}-${{ inputs.niche }}"
           path: transcripts/
           retention-days: 30
+
+      - name: Update Build Tracker
+        if: always()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          pip install pytz -q
+          python3 scripts/build_tracker_writer.py \
+            --workflow topic_scraper.yml \
+            --status "${{ job.status }}"


### PR DESCRIPTION
## What

Adds the `Update Build Tracker` step (`if: always()`) to the 9 production workflows that were missing it. Every workflow run now writes its status to the Build Tracker tab in Content Sheet.

## Before / After

Before: 8 of 17 workflows reported to Build Tracker
After: 17 of 17 workflows report to Build Tracker

## Workflows added

| Workflow | Purpose |
|---|---|
| render-video.yml | FORMAT-001 split-screen reel render |
| blog-generator.yml | WordPress blog post draft |
| inspiration-scraper.yml | Daily scrape to Inspiration Library |
| schedule-posts.yml | Buffer post scheduling |
| process-approved.yml | Move approved posts to queue |
| stocks_pipeline.yml | Stocks intelligence pipeline |
| topic_scraper.yml | Topic cluster scraper |
| daily-content-processor.yml | Daily content processor |
| generate-carousel-content.yml | Hormozi carousel generator |

## Step pattern (identical to content_creator.yml reference)

```yaml
- name: Update Build Tracker
  if: always()
  env:
    SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
  run: |
    pip install pytz -q
    python3 scripts/build_tracker_writer.py \
      --workflow FILENAME.yml \
      --status "${{ job.status }}"
```

Fixes Priority 2 from Productivity & Routine doc (documented 2026-04-21).

Daily Advancer run — 2026-04-25

---
_Generated by [Claude Code](https://claude.ai/code/session_011iLSkqMupywPDoX2T2jAmP)_