### PR TITLE
PR0: OPC_STANDALONE_ALLOWLIST — per-template SH-158 bypass

### DIFF
--- a/.github/workflows/content_creator.yml
+++ b/.github/workflows/content_creator.yml
@@ -90,6 +90,11 @@ on:
         required: false
         default: ''
         type: string
+      opc_standalone_allowlist:
+        description: 'PR0 (2026-05-15) — comma-separated standalone template IDs allowed to survive SH-158 rollback. Empty = full rollback (production-safe). Suggested first allowlist: opc_statement,opc_material_profile.'
+        required: false
+        default: ''
+        type: string
       slide_purpose_pilot:
         description: 'SH-137 — pilot: enable slide_purpose generation + reviewer/auditor purpose-awareness. Default OFF on cron. Manual-only test flag during pilot. See doc 1BDg9ORg.'
         required: false
@@ -155,6 +160,9 @@ jobs:
       # Phase 8 — SH-OPC-SMART-SLIDE-PICKER smart slide planner. Default ON on cron (SH-126, 2026-05-08).
       # Manual runs can override via workflow_dispatch input opc_slide_planner=0 to fall back to legacy planner.
       OPC_SLIDE_PLANNER_ENABLED: ${{ github.event.inputs.opc_slide_planner || '1' }}
+      # PR0 (2026-05-15) — per-template allowlist for SH-158 standalone rollback. Default empty = full rollback (back-compat).
+      # Each ID added must clear its media-relevance gate first. See docs/research/opc_standalone_failure_mode.md.
+      OPC_STANDALONE_ALLOWLIST: ${{ github.event.inputs.opc_standalone_allowlist || '' }}
       # SH-137 — slide_purpose pilot. Default OFF (cron stays unchanged). Manual-only flag for pilot tests.
       # Spec: doc 1BDg9ORggVsWH-WQPBx4iQnYNu2UA5vHWcuNRkXCY5v8 (v3 FINAL).
       # OPC purposes: hook|cost|teach|apply|sources. News purposes: claim|number|evidence|opposition|implication|sources.
@@ -342,6 +350,9 @@ jobs:
       # Phase 8 — SH-OPC-SMART-SLIDE-PICKER smart slide planner. Default ON on cron (SH-126, 2026-05-08).
       # Manual runs can override via workflow_dispatch input opc_slide_planner=0 to fall back to legacy planner.
       OPC_SLIDE_PLANNER_ENABLED: ${{ github.event.inputs.opc_slide_planner || '1' }}
+      # PR0 (2026-05-15) — per-template allowlist for SH-158 standalone rollback. Default empty = full rollback (back-compat).
+      # Each ID added must clear its media-relevance gate first. See docs/research/opc_standalone_failure_mode.md.
+      OPC_STANDALONE_ALLOWLIST: ${{ github.event.inputs.opc_standalone_allowlist || '' }}
       # SH-137 — slide_purpose pilot. Default OFF (cron stays unchanged). Manual-only flag for pilot tests.
       # Spec: doc 1BDg9ORggVsWH-WQPBx4iQnYNu2UA5vHWcuNRkXCY5v8 (v3 FINAL).
       # OPC purposes: hook|cost|teach|apply|sources. News purposes: claim|number|evidence|opposition|implication|sources.

--- a/scripts/content_creator/opc_template_chooser.py
+++ b/scripts/content_creator/opc_template_chooser.py
@@ -732,20 +732,32 @@ def plan_carousel_slides(
     # driveway carousel). Until per-card vision validation is reliable, the
     # conservative all-tip plan is the production path.
     _disable_standalones = os.environ.get("OPC_DISABLE_STANDALONES", "1").strip().lower() in {"1", "true", "yes"}
+    # PR0 (2026-05-15): per-template allowlist — vetted standalones survive the SH-158 rollback.
+    # Default empty = full rollback (back-compat). Each new ID must clear its media-relevance
+    # gate before being added (see docs/research/opc_standalone_failure_mode.md re-enable criteria).
+    _allowlist_raw = os.environ.get("OPC_STANDALONE_ALLOWLIST", "").strip()
+    _allowed_standalones = {t.strip() for t in _allowlist_raw.split(",") if t.strip()}
     if _disable_standalones:
         _safe_tips = {"opc_tip_cover", "opc_tip_stat", "opc_tip_list", "opc_tip_explainer", "opc_tip_sources"}
         rolled_back = []
+        kept_standalones = []
         for slide in plan_slides:
             tid = slide.get("template_id", "")
-            if tid not in _safe_tips:
-                fb = STANDALONE_TO_TIP_FALLBACK.get(tid) or "opc_tip_explainer"
-                rolled_back.append(f"slide{slide['slide']}:{tid}→{fb}")
-                slide["_original_template_id"] = tid
-                slide["template_id"] = fb
-                slide["production_safe"] = True
-                slide["fallback_template_id"] = None
+            if tid in _safe_tips:
+                continue
+            if tid in _allowed_standalones:
+                kept_standalones.append(f"slide{slide['slide']}:{tid}")
+                continue
+            fb = STANDALONE_TO_TIP_FALLBACK.get(tid) or "opc_tip_explainer"
+            rolled_back.append(f"slide{slide['slide']}:{tid}→{fb}")
+            slide["_original_template_id"] = tid
+            slide["template_id"] = fb
+            slide["production_safe"] = True
+            slide["fallback_template_id"] = None
         if rolled_back:
             print(f"  [SH-158] OPC_DISABLE_STANDALONES=1 — rolled back: {', '.join(rolled_back)}")
+        if kept_standalones:
+            print(f"  [PR0] OPC_STANDALONE_ALLOWLIST kept: {', '.join(kept_standalones)}")
 
     return {
         "topic": topic,
@@ -759,6 +771,7 @@ def plan_carousel_slides(
             "All 7 standalone Python builders shipped in Phase 6 (commit 690873f); fallback_template_id is now a defensive escape hatch only.",
             "Banned legacy keys cutout/illustrated cannot appear in any slot.",
             "SH-158 rollback active by default — set OPC_DISABLE_STANDALONES=0 to re-enable standalones once card-image vision validation is verified.",
+            "PR0 (2026-05-15) — vetted standalones may bypass the SH-158 rollback via OPC_STANDALONE_ALLOWLIST=opc_statement,opc_material_profile (comma-separated).",
         ],
     }
 

--- a/scripts/tests/test_opc_standalone_allowlist.py
+++ b/scripts/tests/test_opc_standalone_allowlist.py
@@ -1,0 +1,111 @@
+"""PR0 (2026-05-15) — OPC_STANDALONE_ALLOWLIST behavior.
+
+Proves the SH-158 rollback in opc_template_chooser.plan_carousel_slides()
+honors a per-template allowlist:
+
+  - Empty allowlist (default)        -> standalones still get rolled back to tips.
+  - Allowlist contains picked ID     -> that standalone survives unchanged.
+  - Allowlist contains other IDs     -> non-listed standalones still rolled back.
+
+Background: docs/research/opc_standalone_failure_mode.md.
+"""
+
+import os
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "content_creator"))
+
+from opc_template_chooser import plan_carousel_slides  # noqa: E402
+
+
+# Topic verified by test_opc_comparison_parity.py to pick opc_four_card_grid in slide 3.
+COMPARISON_TOPIC = "Concrete vs Pavers: Which Wins for Driveways?"
+
+
+@contextmanager
+def env(**overrides):
+    """Temporarily override env vars; restore on exit."""
+    snapshot = {k: os.environ.get(k) for k in overrides}
+    try:
+        for k, v in overrides.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, v in snapshot.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _slide3_template(plan):
+    return plan["slides"][2]["template_id"]
+
+
+def _slide3_original(plan):
+    return plan["slides"][2].get("_original_template_id")
+
+
+class OpcStandaloneAllowlistTest(unittest.TestCase):
+    """SH-158 rollback + PR0 allowlist interaction."""
+
+    def test_empty_allowlist_rolls_back_standalone_to_tip(self):
+        """Default behavior preserved: opc_four_card_grid -> tip fallback."""
+        with env(OPC_DISABLE_STANDALONES="1", OPC_STANDALONE_ALLOWLIST=""):
+            plan = plan_carousel_slides(COMPARISON_TOPIC)
+        self.assertEqual(plan["status"], "passed")
+        # Picked standalone got rewritten to a tip family member.
+        self.assertTrue(_slide3_template(plan).startswith("opc_tip_"))
+        # Original ID preserved on the slide for diagnostics.
+        self.assertEqual(_slide3_original(plan), "opc_four_card_grid")
+
+    def test_allowlisted_standalone_survives_rollback(self):
+        """opc_four_card_grid in allowlist -> kept as standalone."""
+        with env(
+            OPC_DISABLE_STANDALONES="1",
+            OPC_STANDALONE_ALLOWLIST="opc_four_card_grid",
+        ):
+            plan = plan_carousel_slides(COMPARISON_TOPIC)
+        self.assertEqual(plan["status"], "passed")
+        self.assertEqual(_slide3_template(plan), "opc_four_card_grid")
+        # No rewrite occurred -> _original_template_id should not be set.
+        self.assertIsNone(_slide3_original(plan))
+
+    def test_unrelated_allowlist_entry_does_not_protect_other_standalones(self):
+        """Allowlist with opc_statement only -> opc_four_card_grid still rolled back."""
+        with env(
+            OPC_DISABLE_STANDALONES="1",
+            OPC_STANDALONE_ALLOWLIST="opc_statement,opc_material_profile",
+        ):
+            plan = plan_carousel_slides(COMPARISON_TOPIC)
+        self.assertEqual(plan["status"], "passed")
+        self.assertTrue(_slide3_template(plan).startswith("opc_tip_"))
+        self.assertEqual(_slide3_original(plan), "opc_four_card_grid")
+
+    def test_allowlist_whitespace_and_blanks_are_tolerated(self):
+        """' opc_four_card_grid , , ' must still allow the template."""
+        with env(
+            OPC_DISABLE_STANDALONES="1",
+            OPC_STANDALONE_ALLOWLIST=" opc_four_card_grid , , ",
+        ):
+            plan = plan_carousel_slides(COMPARISON_TOPIC)
+        self.assertEqual(_slide3_template(plan), "opc_four_card_grid")
+
+    def test_disable_off_ignores_allowlist_entirely(self):
+        """OPC_DISABLE_STANDALONES=0 -> no rollback regardless of allowlist."""
+        with env(OPC_DISABLE_STANDALONES="0", OPC_STANDALONE_ALLOWLIST=""):
+            plan = plan_carousel_slides(COMPARISON_TOPIC)
+        self.assertEqual(_slide3_template(plan), "opc_four_card_grid")
+        self.assertIsNone(_slide3_original(plan))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `OPC_STANDALONE_ALLOWLIST` env var (default empty = current behavior) to `plan_carousel_slides()` SH-158 rollback. Allowlisted standalone IDs survive the rewrite-to-tip rollback while everything else stays on the proven 5-tip path.
- Wires the var into BOTH workflow jobs (`create-content` + `retry-on-failure`) and adds an `opc_standalone_allowlist` `workflow_dispatch` input (mirrors existing `opc_slide_planner` pattern).
- 5 new unit tests in `scripts/tests/test_opc_standalone_allowlist.py` cover back-compat, allowlisted survival, unrelated-entry isolation, whitespace tolerance, and `OPC_DISABLE_STANDALONES=0` short-circuit.

## Why now

Phase 0 forensics (`docs/research/opc_standalone_failure_mode.md`) proved the SH-158 rollback was triggered by **media relevance**, not renderer absence. Templates with low/no required media (`opc_statement`, `opc_material_profile`) can ship safely without waiting for the full vision-validation gate — unblocking variable-content carousels in days instead of weeks.

This is the safest unit of progress: zero behavior change at default, opt-in per template, audited tradeoff.

## Default safety

Empty allowlist = unchanged production behavior. Cron is unaffected. Operators must explicitly pass the input on a manual run to activate.

## Activation (one-week signal run)

```
gh workflow run content_creator.yml \
  -f opc_standalone_allowlist=opc_statement,opc_material_profile \
  -f manual_mode=true -f manual_niche=opc -f manual_topic="<your topic>"
```

## Test plan

- [x] All 5 new unit tests pass on Python 3.12
- [x] Pre-existing chooser tests unaffected (chooser file imports unchanged)
- [x] Workflow YAML lint: env var added in both job env blocks (lines 158, 348)
- [ ] Phase 5 manual run with `opc_standalone_allowlist=opc_statement` on a real OPC topic
- [ ] One-week signal observation before expanding allowlist

## Out of scope (future PRs)

- Variable slide-count refactor of `plan_carousel_slides()` (PR1)
- Bundle-aware `check_slide_plan()` validator (PR1)
- `opc_template_catalog.json` + `opc_template_bundles.json` (PR1)
- Per-card vision relevance gate using `VISION_API_KEY` (PR2 — currently missing from secrets)
- Re-enable `opc_four_card_grid` etc. (PR3, gated on PR2)

## References

- Pipeline Fix Master Checklist row 129
- Flow Plans Tracker row 22 (OPC Carousel Pipeline — Audit Remediation Plan 2026-05-12)
- AIOX-architect + AIOX-devops audit completed 2026-05-15
- Phase 0 artifact: `docs/research/opc_standalone_failure_mode.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)