### PR TITLE
[codex] STORY-001: add route contract loader stub

### DIFF
--- a/scripts/content_creator/contract_loader.py
+++ b/scripts/content_creator/contract_loader.py
@@ -1,0 +1,39 @@
+"""STORY-001 route-specific editorial contract loader.
+
+This is intentionally a stub boundary. Operational routing stays in
+``scripts/routing.py``; downstream storytelling phases can depend on this module
+without learning file paths or touching the ROUTES dict.
+"""
+
+from __future__ import annotations
+
+
+_STUB_VERSION = "0.1.0-stub"
+
+_NEWS_ALIASES = {"news", "brazil", "usa", "br", "us", "brazil_news", "usa_news", "news_brazil", "news_usa"}
+_OPC_ALIASES = {"opc", "content", "oak_park", "oak-park"}
+
+
+def _normalize_story_route(route: str) -> str:
+    value = (route or "").strip().lower()
+    if value in _OPC_ALIASES:
+        return "opc"
+    if value in _NEWS_ALIASES:
+        return "news"
+    if value == "unrouted":
+        raise ValueError("Cannot load storytelling contract for unrouted content")
+    raise ValueError(f"Unknown storytelling route: {route!r}")
+
+
+def load_contract(route: str) -> dict:
+    """Return the route-specific editorial contract stub for STORY-001.
+
+    STORY-002/003 will replace this stub content with real OPC/News contract
+    fields. Until then, this function only proves the route-specific boundary.
+    """
+    normalized = _normalize_story_route(route)
+    return {
+        "route": normalized,
+        "version": _STUB_VERSION,
+        "loaded": False,
+    }

--- a/scripts/tests/test_contract_loader.py
+++ b/scripts/tests/test_contract_loader.py
@@ -1,0 +1,41 @@
+"""Tests for STORY-001 route-specific contract loader stub."""
+
+import unittest
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "content_creator"))
+
+from contract_loader import load_contract  # noqa: E402
+
+
+class ContractLoaderTest(unittest.TestCase):
+    def test_loads_opc_stub(self):
+        self.assertEqual(
+            load_contract("opc"),
+            {"route": "opc", "version": "0.1.0-stub", "loaded": False},
+        )
+
+    def test_loads_news_stub(self):
+        self.assertEqual(
+            load_contract("news"),
+            {"route": "news", "version": "0.1.0-stub", "loaded": False},
+        )
+
+    def test_maps_existing_news_route_aliases_to_news_contract(self):
+        self.assertEqual(load_contract("brazil")["route"], "news")
+        self.assertEqual(load_contract("usa")["route"], "news")
+
+    def test_unrouted_is_kill_gate_placeholder(self):
+        with self.assertRaises(ValueError):
+            load_contract("unrouted")
+
+    def test_unknown_route_raises(self):
+        with self.assertRaises(ValueError):
+            load_contract("stocks")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Adds the STORY-001 contract-loader boundary for route-specific storytelling contracts:

- `scripts/content_creator/contract_loader.py`
- `scripts/tests/test_contract_loader.py`

The loader keeps operational routing separate from editorial contracts. It does not modify `routing.py::get_route()` or any production call sites.

## Contract behavior

- `load_contract("opc")` returns an OPC-only stub
- `load_contract("news")` returns a News-only stub
- `brazil` / `usa` aliases resolve to the News contract boundary
- `unrouted` raises `ValueError` as the kill-gate placeholder
- unknown routes raise `ValueError`

## Safety

- Additive only
- No Drive/Sheets/workflow/env wiring
- No claim ledger, story outline, render, email, Buffer, or production output changes
- `routing.get_route()` return shape is untouched

## Validation

- `python3 -m unittest scripts/tests/test_contract_loader.py`
