### PR TITLE
[codex] SH-145: wire story metadata behind flag

### DIFF
--- a/scripts/content_creator/carousel_builder.py
+++ b/scripts/content_creator/carousel_builder.py
@@ -12,6 +12,8 @@ try:
     from _llm_fallback import llm_text as _llm_text_cascade
 except Exception:
     _llm_text_cascade = None
+from contract_loader import load_contract
+from story_outline import attach_story_outline, story_pipeline_enabled
 
 ANTHROPIC_KEY  = os.environ.get("CLAUDE_KEY_4_CONTENT", "")
 OPENAI_KEY     = os.environ.get("OPENAI_API_KEY", "")
@@ -1374,16 +1376,42 @@ Return ONLY a valid JSON object:
             return None
 
 
+def _attach_story_pipeline_metadata(content, *, topic, niche, template_key=None):
+    """Attach STORY/SH metadata only when STORY_PIPELINE_V2_ENABLED is on."""
+    if not story_pipeline_enabled() or not isinstance(content, dict):
+        return content
+
+    route = "news" if niche in ("brazil", "usa") else niche
+    slide_count = None
+    if niche == "opc":
+        slide_count = 5
+
+    updated = attach_story_outline(
+        content,
+        topic=topic,
+        niche=niche,
+        template_key=template_key,
+        slide_count=slide_count,
+    )
+    if isinstance(updated, dict):
+        updated["editorial_contract"] = load_contract(route)
+    return updated
+
+
 def generate_carousel_content(topic, niche, template_key=None, brief="", model="claude-sonnet-4-6", slide_plan=None):
     # Special templates checked BEFORE the generic niche short-circuit
     if template_key == "progress":
-        return generate_progress_content(topic, brief)
+        content = generate_progress_content(topic, brief)
+        return _attach_story_pipeline_metadata(content, topic=topic, niche=niche, template_key=template_key)
     if template_key == "dados-ou-agenda":
-        return generate_dados_content(topic, brief)
+        content = generate_dados_content(topic, brief)
+        return _attach_story_pipeline_metadata(content, topic=topic, niche=niche, template_key=template_key)
     if template_key == "verdade-pela-metade":
-        return generate_verdade_content(topic, brief)
+        content = generate_verdade_content(topic, brief)
+        return _attach_story_pipeline_metadata(content, topic=topic, niche=niche, template_key=template_key)
     if niche in ("brazil", "usa"):
-        return generate_brazil_content(topic, brief, model=model)
+        content = generate_brazil_content(topic, brief, model=model)
+        return _attach_story_pipeline_metadata(content, topic=topic, niche=niche, template_key=template_key)
     if not template_key:
         template_key = OPC_TEMPLATE if niche == "opc" else BRAZIL_TEMPLATE
 
@@ -1627,7 +1655,8 @@ Rules:
             if parsed.get("needs_longer_format"):
                 print(f"  [format] ⚠ needs_longer_format=true — topic may be too broad for 5 slides: {topic!r}")
                 parsed["_longer_format_warning"] = True
-            return _apply_opc_hook_answer_contract(parsed, topic)
+            content = _apply_opc_hook_answer_contract(parsed, topic)
+            return _attach_story_pipeline_metadata(content, topic=topic, niche=niche, template_key=template_key)
         except json.JSONDecodeError as e:
             print(f"  OPC JSON parse error (attempt {attempt+1}): {e}")
             continue

--- a/scripts/content_creator/carousel_builder.py
+++ b/scripts/content_creator/carousel_builder.py
@@ -12,8 +12,15 @@ try:
     from _llm_fallback import llm_text as _llm_text_cascade
 except Exception:
     _llm_text_cascade = None
-from contract_loader import load_contract
-from story_outline import attach_story_outline, story_pipeline_enabled
+try:
+    from contract_loader import load_contract
+    from story_outline import attach_story_outline, story_pipeline_enabled
+except Exception:
+    load_contract = None
+    attach_story_outline = None
+
+    def story_pipeline_enabled(env=None):
+        return False
 
 ANTHROPIC_KEY  = os.environ.get("CLAUDE_KEY_4_CONTENT", "")
 OPENAI_KEY     = os.environ.get("OPENAI_API_KEY", "")
@@ -1378,7 +1385,12 @@ Return ONLY a valid JSON object:
 
 def _attach_story_pipeline_metadata(content, *, topic, niche, template_key=None):
     """Attach STORY/SH metadata only when STORY_PIPELINE_V2_ENABLED is on."""
-    if not story_pipeline_enabled() or not isinstance(content, dict):
+    if (
+        load_contract is None
+        or attach_story_outline is None
+        or not story_pipeline_enabled()
+        or not isinstance(content, dict)
+    ):
         return content
 
     route = "news" if niche in ("brazil", "usa") else niche

--- a/scripts/tests/test_story_pipeline_integration.py
+++ b/scripts/tests/test_story_pipeline_integration.py
@@ -1,0 +1,67 @@
+"""Integration tests for SH-145/STORY-001 metadata attachment."""
+
+import os
+import json
+import unittest
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "content_creator"))
+
+import carousel_builder  # noqa: E402
+
+
+class StoryPipelineIntegrationTest(unittest.TestCase):
+    def sample_content(self):
+        return {
+            "headline": "3 COSTLY MISTAKES",
+            "subhead": "$20K mistake before you sign",
+            "hook_frame": "costly_mistake",
+            "viewer_question": "Am I making this mistake right now?",
+            "cta": "SAVE BEFORE YOUR NEXT BID.",
+            "sources": ["Florida Building Code", "UF IFAS"],
+            "slides": [
+                {"slide": 2, "visual_hint": "context-image", "context_image_query": "concrete patio drainage residential"},
+                {"slide": 3, "visual_hint": "context-image", "context_image_query": "channel drain installation patio"},
+                {"slide": 4, "visual_hint": "context-image", "context_image_query": "contractor level patio slope"},
+            ],
+        }
+
+    def test_flag_off_returns_generator_content_object_unchanged(self):
+        content = self.sample_content()
+        before = json.dumps(content, sort_keys=True)
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "0"}, clear=False):
+            with patch.object(carousel_builder, "generate_progress_content", return_value=content):
+                result = carousel_builder.generate_carousel_content("Patio drainage", "opc", template_key="progress")
+
+        self.assertIs(result, content)
+        self.assertEqual(json.dumps(result, sort_keys=True), before)
+        self.assertNotIn("story_outline", result)
+        self.assertNotIn("editorial_contract", result)
+
+    def test_flag_on_attaches_story_outline_and_opc_contract(self):
+        content = self.sample_content()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            with patch.object(carousel_builder, "generate_progress_content", return_value=content):
+                result = carousel_builder.generate_carousel_content("Patio drainage", "opc", template_key="progress")
+
+        self.assertIsNot(result, content)
+        self.assertNotIn("story_outline", content)
+        self.assertEqual(result["story_outline"]["route"], "opc")
+        self.assertEqual(result["editorial_contract"], {"route": "opc", "version": "0.1.0-stub", "loaded": False})
+
+    def test_flag_on_maps_brazil_route_to_news_contract(self):
+        content = self.sample_content()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            with patch.object(carousel_builder, "generate_brazil_content", return_value=content):
+                result = carousel_builder.generate_carousel_content("Brazil topic", "brazil")
+
+        self.assertEqual(result["story_outline"]["route"], "brazil")
+        self.assertEqual(result["editorial_contract"], {"route": "news", "version": "0.1.0-stub", "loaded": False})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Integrates the already-merged SH-145/STORY-001 foundation behind `STORY_PIPELINE_V2_ENABLED`:

- `generate_carousel_content()` now routes generated content through one metadata helper.
- When the flag is OFF, the helper returns the original content object unchanged.
- When the flag is ON, it adds:
  - `content["story_outline"]` from `story_outline.attach_story_outline()`
  - `content["editorial_contract"]` from `contract_loader.load_contract()`

## Safety / AIOX checklist

- [x] Hook is outside the banned functions: `build_html`, `process_one_topic`, `check_built_post`, `audit_post`
- [x] No edits to `content_creator.yml`, `main.py`, `carousel_reviewer.py`, `content_auditor.py`, email scripts, or workflows
- [x] `STORY_PIPELINE_V2_ENABLED=0` returns the exact same content object and JSON snapshot
- [x] `STORY_PIPELINE_V2_ENABLED=1` only adds metadata fields
- [x] No LLM call added
- [x] No renderer, email, Buffer, Drive, or workflow behavior changes

## Validation

- `python3 -m unittest scripts/tests/test_story_pipeline_integration.py scripts/tests/test_story_outline.py scripts/tests/test_contract_loader.py`
