### PR TITLE
SH-148: visual cadence gate contract (PR A — module only)

### DIFF
--- a/scripts/content_creator/visual_cadence_gate.py
+++ b/scripts/content_creator/visual_cadence_gate.py
@@ -1,0 +1,214 @@
+"""SH-148 — Visual cadence gate contract.
+
+Detects when a carousel ships with more than one consecutive text-only
+middle slide. Pure validation helper. No LLM, no integration into
+production reviewer/auditor yet — that ships as a separate audit-required PR.
+
+Rule source: CLAUDE.md "VISUAL-EVERY-OTHER-SLIDE" section +
+~/.claude/projects/-Users-priscilahigashi/memory/feedback_visual_every_other_slide.md
+
+Reading of the rule (strictest interpretation):
+- Cover slide (index 1 / slide=1) and sources slide are exempt
+- For middle slides, max 1 consecutive ``visual_hint == "none"`` allowed
+- 2+ consecutive ``none`` middle slides => violation
+
+``carousel_builder.py`` emits ``visual_hint`` per slide with values:
+``bio-card`` / ``product-photo`` / ``context-image`` / ``icon-row`` / ``none``.
+Missing or empty visual_hint is treated as ``none`` (conservative).
+"""
+
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+
+_FLAG = "STORY_PIPELINE_V2_ENABLED"
+
+_NEWS_ALIASES = {
+    "news", "brazil", "usa", "br", "us",
+    "brazil_news", "usa_news", "news_brazil", "news_usa",
+}
+_OPC_ALIASES = {"opc", "content", "oak_park", "oak-park"}
+
+# Hints that count as carrying a visual anchor
+_VISUAL_ANCHOR_HINTS = {"bio-card", "product-photo", "context-image", "icon-row"}
+
+# Maximum allowed consecutive text-only middle slides
+_MAX_CONSECUTIVE_TEXT_ONLY = 1
+
+
+class VisualCadenceGateError(ValueError):
+    """Raised when the cadence gate cannot run for the requested route."""
+
+
+def cadence_gate_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return True only when the storytelling pipeline flag is explicitly enabled."""
+    source = os.environ if env is None else env
+    return str(source.get(_FLAG, "0")).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _normalize_cadence_route(route: str) -> str:
+    value = (route or "").strip().lower()
+    if value in _OPC_ALIASES:
+        return "opc"
+    if value in _NEWS_ALIASES:
+        return "news"
+    if value == "unrouted":
+        raise VisualCadenceGateError("Cannot run cadence gate for unrouted content")
+    raise VisualCadenceGateError(f"Unknown cadence gate route: {route!r}")
+
+
+@dataclass(frozen=True)
+class CadenceViolation:
+    start_slide_index: int
+    end_slide_index: int
+    consecutive_count: int
+    reason: str
+
+
+def _is_cover_slide(slide: dict[str, Any], position: int) -> bool:
+    if position == 1:
+        return True
+    if slide.get("slide") == 1:
+        return True
+    if str(slide.get("type") or "").strip().lower() == "cover":
+        return True
+    if str(slide.get("slide_purpose") or "").strip().lower() == "hook" and position <= 1:
+        return True
+    return False
+
+
+def _is_sources_slide(slide: dict[str, Any]) -> bool:
+    purpose = str(slide.get("slide_purpose") or "").strip().lower()
+    if purpose == "sources":
+        return True
+    slide_type = str(slide.get("type") or "").strip().lower()
+    if slide_type in {"sources", "source"}:
+        return True
+    return False
+
+
+def _has_visual_anchor(slide: dict[str, Any]) -> bool:
+    hint = str(slide.get("visual_hint") or "").strip().lower()
+    if hint in _VISUAL_ANCHOR_HINTS:
+        return True
+    # Defensive: a slide that already carries a sticker, bio_card, or product
+    # photo without an explicit visual_hint still counts as a visual anchor.
+    if slide.get("sticker_slot") or slide.get("sticker_image") or slide.get("sticker_url"):
+        return True
+    if slide.get("bio_card") or slide.get("bio_cards"):
+        return True
+    if slide.get("product_photo") or slide.get("product_image"):
+        return True
+    return False
+
+
+def _slide_index(slide: dict[str, Any], position: int) -> int:
+    raw = slide.get("slide")
+    if isinstance(raw, int):
+        return raw
+    return position
+
+
+def check_visual_cadence(
+    content: dict[str, Any], *, route: str
+) -> list[CadenceViolation]:
+    """Return one CadenceViolation per stretch of 2+ consecutive text-only middle slides.
+
+    Empty list = pass. Cover and sources slides are exempt.
+    """
+    _normalize_cadence_route(route)  # raises for unrouted/unknown
+    if not isinstance(content, dict):
+        raise VisualCadenceGateError("content must be a dict")
+
+    violations: list[CadenceViolation] = []
+    slides = content.get("slides")
+    if not isinstance(slides, list):
+        return violations
+
+    run_start_pos: int | None = None
+    run_start_index: int | None = None
+    run_end_index: int | None = None
+    run_count = 0
+
+    def flush_run() -> None:
+        nonlocal run_start_pos, run_start_index, run_end_index, run_count
+        if run_count > _MAX_CONSECUTIVE_TEXT_ONLY:
+            assert run_start_index is not None and run_end_index is not None
+            violations.append(
+                CadenceViolation(
+                    start_slide_index=run_start_index,
+                    end_slide_index=run_end_index,
+                    consecutive_count=run_count,
+                    reason=(
+                        f"{run_count} consecutive text-only middle slides "
+                        f"(max {_MAX_CONSECUTIVE_TEXT_ONLY} allowed)"
+                    ),
+                )
+            )
+        run_start_pos = None
+        run_start_index = None
+        run_end_index = None
+        run_count = 0
+
+    for position, slide in enumerate(slides, start=1):
+        if not isinstance(slide, dict):
+            flush_run()
+            continue
+        if _is_cover_slide(slide, position) or _is_sources_slide(slide):
+            flush_run()
+            continue
+        if _has_visual_anchor(slide):
+            flush_run()
+            continue
+        # Middle slide with no visual anchor -> extend the run
+        idx = _slide_index(slide, position)
+        if run_start_pos is None:
+            run_start_pos = position
+            run_start_index = idx
+        run_end_index = idx
+        run_count += 1
+
+    flush_run()
+    return violations
+
+
+def attach_cadence_report(
+    content: dict[str, Any] | None,
+    *,
+    route: str,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any] | None:
+    """Attach a ``visual_cadence`` report when STORY_PIPELINE_V2_ENABLED is on.
+
+    Flag OFF -> returns the input object unchanged (same identity).
+    Flag ON  -> deep-copies, attaches ``visual_cadence`` schema, returns the copy.
+    """
+    if content is None or not cadence_gate_enabled(env):
+        return content
+    if not isinstance(content, dict):
+        raise VisualCadenceGateError("content must be a dict or None")
+
+    normalized = _normalize_cadence_route(route)
+    violations = check_visual_cadence(content, route=route)
+    updated = deepcopy(content)
+    updated["visual_cadence"] = {
+        "schema_version": "visual_cadence.v0.1",
+        "sh_id": "SH-148",
+        "route": normalized,
+        "max_consecutive_text_only": _MAX_CONSECUTIVE_TEXT_ONLY,
+        "violations": [
+            {
+                "start_slide_index": v.start_slide_index,
+                "end_slide_index": v.end_slide_index,
+                "consecutive_count": v.consecutive_count,
+                "reason": v.reason,
+            }
+            for v in violations
+        ],
+        "pass": len(violations) == 0,
+    }
+    return updated

--- a/scripts/tests/test_visual_cadence_gate.py
+++ b/scripts/tests/test_visual_cadence_gate.py
@@ -1,0 +1,278 @@
+"""Tests for SH-148 visual cadence gate contract."""
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "content_creator"))
+
+from visual_cadence_gate import (  # noqa: E402
+    CadenceViolation,
+    VisualCadenceGateError,
+    attach_cadence_report,
+    cadence_gate_enabled,
+    check_visual_cadence,
+)
+
+
+def _slide(slide_num, **fields):
+    base = {"slide": slide_num}
+    base.update(fields)
+    return base
+
+
+class VisualCadenceGateTest(unittest.TestCase):
+    # --- happy paths --------------------------------------------------------
+
+    def test_alternating_pattern_passes(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="product-photo"),
+                _slide(3, visual_hint="none"),
+                _slide(4, visual_hint="context-image"),
+                _slide(5, slide_purpose="sources"),
+            ]
+        }
+        self.assertEqual(check_visual_cadence(content, route="opc"), [])
+
+    def test_all_visuals_passes(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="bio-card"),
+                _slide(3, visual_hint="product-photo"),
+                _slide(4, visual_hint="context-image"),
+                _slide(5, slide_purpose="sources"),
+            ]
+        }
+        self.assertEqual(check_visual_cadence(content, route="brazil"), [])
+
+    def test_single_text_only_middle_slide_passes(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="context-image"),
+                _slide(3, visual_hint="none"),
+                _slide(4, visual_hint="product-photo"),
+                _slide(5, slide_purpose="sources"),
+            ]
+        }
+        self.assertEqual(check_visual_cadence(content, route="opc"), [])
+
+    # --- violation paths ----------------------------------------------------
+
+    def test_two_consecutive_text_only_triggers_violation(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="none"),
+                _slide(3, visual_hint="none"),
+                _slide(4, visual_hint="product-photo"),
+                _slide(5, slide_purpose="sources"),
+            ]
+        }
+        violations = check_visual_cadence(content, route="opc")
+        self.assertEqual(len(violations), 1)
+        v = violations[0]
+        self.assertEqual(v.consecutive_count, 2)
+        self.assertEqual(v.start_slide_index, 2)
+        self.assertEqual(v.end_slide_index, 3)
+
+    def test_three_consecutive_text_only_triggers_one_violation(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="none"),
+                _slide(3, visual_hint="none"),
+                _slide(4, visual_hint="none"),
+                _slide(5, slide_purpose="sources"),
+            ]
+        }
+        violations = check_visual_cadence(content, route="brazil")
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].consecutive_count, 3)
+
+    def test_two_separate_runs_each_violate(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="none"),
+                _slide(3, visual_hint="none"),
+                _slide(4, visual_hint="product-photo"),
+                _slide(5, visual_hint="none"),
+                _slide(6, visual_hint="none"),
+                _slide(7, slide_purpose="sources"),
+            ]
+        }
+        violations = check_visual_cadence(content, route="opc")
+        self.assertEqual(len(violations), 2)
+        self.assertEqual(violations[0].start_slide_index, 2)
+        self.assertEqual(violations[1].start_slide_index, 5)
+
+    def test_missing_visual_hint_treated_as_text_only(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2),  # no visual_hint at all
+                _slide(3),  # no visual_hint
+                _slide(4, slide_purpose="sources"),
+            ]
+        }
+        violations = check_visual_cadence(content, route="opc")
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].consecutive_count, 2)
+
+    def test_empty_string_visual_hint_treated_as_text_only(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint=""),
+                _slide(3, visual_hint=""),
+                _slide(4, slide_purpose="sources"),
+            ]
+        }
+        violations = check_visual_cadence(content, route="brazil")
+        self.assertEqual(len(violations), 1)
+
+    # --- cover/sources exemption -------------------------------------------
+
+    def test_cover_with_no_visual_hint_does_not_count(self):
+        content = {
+            "slides": [
+                _slide(1),  # cover by position 1, no visual_hint -> exempt
+                _slide(2, visual_hint="product-photo"),
+                _slide(3, visual_hint="none"),
+                _slide(4, slide_purpose="sources"),
+            ]
+        }
+        self.assertEqual(check_visual_cadence(content, route="opc"), [])
+
+    def test_sources_with_no_visual_hint_does_not_extend_run(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="none"),  # single text-only middle slide
+                _slide(3, slide_purpose="sources"),  # exempt, ends run
+            ]
+        }
+        self.assertEqual(check_visual_cadence(content, route="brazil"), [])
+
+    # --- defensive anchor detection ----------------------------------------
+
+    def test_sticker_without_visual_hint_counts_as_anchor(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, sticker_slot="someone.png"),  # no visual_hint set
+                _slide(3, visual_hint="none"),
+                _slide(4, slide_purpose="sources"),
+            ]
+        }
+        self.assertEqual(check_visual_cadence(content, route="brazil"), [])
+
+    def test_bio_card_without_visual_hint_counts_as_anchor(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, bio_cards=[{"name": "X", "photo": "x.png"}]),
+                _slide(3, visual_hint="none"),
+                _slide(4, slide_purpose="sources"),
+            ]
+        }
+        self.assertEqual(check_visual_cadence(content, route="brazil"), [])
+
+    # --- route handling ----------------------------------------------------
+
+    def test_unrouted_raises(self):
+        with self.assertRaises(VisualCadenceGateError):
+            check_visual_cadence({"slides": []}, route="unrouted")
+
+    def test_unknown_route_raises(self):
+        with self.assertRaises(VisualCadenceGateError):
+            check_visual_cadence({"slides": []}, route="stocks")
+
+    def test_route_aliases_resolve(self):
+        for route in ("opc", "OPC", "oak-park", "news", "brazil", "usa", "br", "us"):
+            check_visual_cadence({"slides": []}, route=route)
+
+    # --- attach_cadence_report (flag-gated) --------------------------------
+
+    def test_flag_off_returns_same_object_and_byte_identical(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="none"),
+                _slide(3, visual_hint="none"),
+                _slide(4, slide_purpose="sources"),
+            ]
+        }
+        before = json.dumps(content, sort_keys=True)
+        result = attach_cadence_report(
+            content, route="opc", env={"STORY_PIPELINE_V2_ENABLED": "0"}
+        )
+        self.assertIs(result, content)
+        self.assertEqual(json.dumps(result, sort_keys=True), before)
+        self.assertNotIn("visual_cadence", content)
+
+    def test_flag_off_default_env_returns_same_object(self):
+        content = {"slides": [_slide(1, type="cover")]}
+        env_without_flag = {k: v for k, v in os.environ.items() if k != "STORY_PIPELINE_V2_ENABLED"}
+        result = attach_cadence_report(content, route="opc", env=env_without_flag)
+        self.assertIs(result, content)
+
+    def test_flag_on_attaches_report_without_mutating_input(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="none"),
+                _slide(3, visual_hint="none"),
+                _slide(4, slide_purpose="sources"),
+            ]
+        }
+        result = attach_cadence_report(
+            content, route="brazil", env={"STORY_PIPELINE_V2_ENABLED": "1"}
+        )
+        self.assertIsNot(result, content)
+        self.assertNotIn("visual_cadence", content)
+        self.assertEqual(result["visual_cadence"]["sh_id"], "SH-148")
+        self.assertEqual(result["visual_cadence"]["route"], "news")
+        self.assertEqual(result["visual_cadence"]["max_consecutive_text_only"], 1)
+        self.assertFalse(result["visual_cadence"]["pass"])
+        self.assertEqual(len(result["visual_cadence"]["violations"]), 1)
+
+    def test_flag_on_pass_when_cadence_clean(self):
+        content = {
+            "slides": [
+                _slide(1, type="cover"),
+                _slide(2, visual_hint="product-photo"),
+                _slide(3, visual_hint="none"),
+                _slide(4, visual_hint="context-image"),
+                _slide(5, slide_purpose="sources"),
+            ]
+        }
+        result = attach_cadence_report(
+            content, route="opc", env={"STORY_PIPELINE_V2_ENABLED": "1"}
+        )
+        self.assertTrue(result["visual_cadence"]["pass"])
+        self.assertEqual(result["visual_cadence"]["violations"], [])
+
+    def test_flag_on_none_content_returns_none(self):
+        result = attach_cadence_report(
+            None, route="brazil", env={"STORY_PIPELINE_V2_ENABLED": "1"}
+        )
+        self.assertIsNone(result)
+
+    def test_flag_truthy_values(self):
+        self.assertFalse(cadence_gate_enabled({}))
+        self.assertFalse(cadence_gate_enabled({"STORY_PIPELINE_V2_ENABLED": "0"}))
+        self.assertTrue(cadence_gate_enabled({"STORY_PIPELINE_V2_ENABLED": "1"}))
+        self.assertTrue(cadence_gate_enabled({"STORY_PIPELINE_V2_ENABLED": "true"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the **SH-148 visual cadence gate** as a pure additive contract module — no production behavior change. Mirrors the SH-145/146/147 pattern.

This is **PR A** of a two-part SH-148 plan:
- **PR A (this PR)** — the contract module + tests, NOT imported anywhere yet. Dead code until PR B.
- **PR B (future)** — integration into `carousel_reviewer.py` / `content_auditor.py` behind `STORY_PIPELINE_V2_ENABLED`. Separate AIOX-audited PR.

## What it does

Flags 2+ consecutive text-only middle slides per CLAUDE.md `VISUAL-EVERY-OTHER-SLIDE`:

> carousels must NEVER ship with 3+ consecutive text-only slides between cover and sources. At least every-other middle slide carries a visual anchor.

Rule (strictest interpretation):
- Cover slide (position 1 / `type="cover"` / `slide=1`) and sources slide (`slide_purpose="sources"` / `type="sources"`) are exempt
- For middle slides, max **1 consecutive `visual_hint=="none"`** allowed
- 2+ consecutive triggers violation, returning each run as a separate `CadenceViolation` with start/end indexes

Visual anchor hints recognized: `bio-card`, `product-photo`, `context-image`, `icon-row`.

Defensive anchor detection — a slide with `sticker_slot`, `bio_cards`, or `product_photo` set but no explicit `visual_hint` still counts as an anchor.

## What it does NOT do

- ❌ Does not modify `carousel_builder.py`, `carousel_reviewer.py`, `content_auditor.py`, `main.py`, or any workflow
- ❌ Does not call any LLM
- ❌ Is not imported by any production file (verified: `grep -rn "visual_cadence_gate" scripts/`)
- ❌ Has no effect on production output, flag on or off

## Files

| File | Lines | Purpose |
|---|---|---|
| `scripts/content_creator/visual_cadence_gate.py` | +234 | pure validator |
| `scripts/tests/test_visual_cadence_gate.py` | +258 | 21 unit tests |

## Tests

- `python3 -m unittest scripts.tests.test_visual_cadence_gate` -> **21/21 OK**
- Full storytelling suite (story_outline + contract_loader + story_pipeline_integration + claim_ledger + named_person_face_gate + visual_cadence_gate) -> **58/58 OK**

Coverage:
- alternating pattern (text/visual/text/visual) -> pass
- all visuals -> pass
- single text-only middle slide -> pass
- 2 consecutive text-only -> 1 violation
- 3 consecutive text-only -> 1 violation (count=3)
- two separate runs of 2+ -> 2 violations
- missing `visual_hint` -> treated as `none` (conservative)
- empty-string `visual_hint` -> treated as `none`
- cover slide with no visual_hint -> exempt
- sources slide -> exempt, does not extend a run
- sticker without visual_hint -> counts as anchor
- bio_cards without visual_hint -> counts as anchor
- unrouted / unknown route -> raises `VisualCadenceGateError`
- route aliases (`opc`/`oak-park`/`news`/`brazil`/`usa`/`br`/`us`) -> resolve
- flag OFF -> same object, byte-identical JSON, no `visual_cadence` key
- flag ON -> deep-copy, attaches `visual_cadence` schema, original dict unmutated
- flag truthy values match siblings

## AIOX self-audit (mirrors SH-145/147 checklist)

- [x] 2 files only, both new
- [x] Zero edits to `carousel_builder.py` / `main.py` / `content_creator.yml` / `carousel_reviewer.py` / `content_auditor.py` / email / Buffer
- [x] Pure Python, no LLM / Anthropic / OpenAI imports
- [x] OPC and News routes handled separately (`_normalize_cadence_route`); unrouted raises clear error
- [x] Same `STORY_PIPELINE_V2_ENABLED` flag as siblings
- [x] Module not imported by any production file -> byte-identical output guaranteed
- [x] Tests cover happy/violation paths, cover/sources exemption, defensive anchor detection, route-raise, additive-only flag semantics
- [x] All 58 storytelling tests pass on local merge

## Status

**DRAFT** -> awaiting AIOX audit + Priscila's final diff sanity check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)