### PR TITLE
SH-147 PR B: wire face gate into carousel_reviewer behind flag

### DIFF
--- a/scripts/content_creator/carousel_reviewer.py
+++ b/scripts/content_creator/carousel_reviewer.py
@@ -43,6 +43,18 @@ except Exception:
     Image = None
     ImageStat = None
 
+# SH-147 PR B — named-person face gate. Import guarded so a syntax error
+# in the gate module can never break the reviewer. Gate behavior is also
+# flag-gated below — module presence alone changes no behavior.
+try:
+    from named_person_face_gate import (
+        check_named_person_face_coverage,
+        NamedPersonFaceGateError,
+    )
+except Exception:
+    check_named_person_face_coverage = None
+    NamedPersonFaceGateError = Exception
+
 # Env vars
 SHEETS_TOKEN     = os.environ.get("SHEETS_TOKEN", "")
 ALERT_EMAIL      = os.environ.get("ALERT_EMAIL", "priscila@oakpark-construction.com")
@@ -1016,6 +1028,37 @@ def check_opc_professional_ethics(content: dict) -> list[str]:
             )
             break
     return issues
+
+
+def _run_face_gate_check(content: dict, niche: str) -> list[str]:
+    """SH-147 PR B integration — named-person face gate review hook.
+
+    Flag-gated by ``STORY_PIPELINE_V2_ENABLED``. Default OFF means this
+    returns an empty list and the reviewer is byte-identical to pre-PR-B.
+
+    When ON, scans the content dict for ``<strong>FirstName LastName</strong>``
+    patterns and flags any without a face treatment (sticker / bio-card /
+    bio-initials / HTML class markers). Returns one issue string per violation,
+    prefixed ``[face-gate]`` so review emails and tracker rows can grep it.
+    """
+    if check_named_person_face_coverage is None:
+        return []
+    flag = str(os.environ.get("STORY_PIPELINE_V2_ENABLED", "0")).strip().lower()
+    if flag not in {"1", "true", "yes", "on"}:
+        return []
+    if niche not in ("opc", "brazil", "usa", "news"):
+        return []
+    try:
+        violations = check_named_person_face_coverage(content or {}, route=niche)
+    except NamedPersonFaceGateError:
+        # Unrouted/unknown route — silent skip, never break the reviewer.
+        return []
+    except Exception as exc:  # pragma: no cover - defensive
+        return [f"[face-gate] gate failed with {type(exc).__name__}: {exc}"]
+    return [
+        f"[face-gate] slide {v.slide_index}: {v.person_name} — {v.reason}"
+        for v in violations
+    ]
 
 
 def check_news_template_dispatch(content: dict, niche: str) -> list[str]:
@@ -2337,6 +2380,8 @@ def check_built_post(result: dict) -> dict:
     all_issues = []
     _content_dict = result.get("content", {}) or {}
     all_issues.extend(check_news_template_dispatch(_content_dict, niche))
+    # SH-147 PR B — face gate. No-op when STORY_PIPELINE_V2_ENABLED is off.
+    all_issues.extend(_run_face_gate_check(_content_dict, niche))
 
     # 0. Phase 5 — smart slide-plan gates (Phase 4 picker output validation).
     # Runs FIRST so a hallucinated/banned plan blocks the post before any

--- a/scripts/tests/test_face_gate_reviewer_integration.py
+++ b/scripts/tests/test_face_gate_reviewer_integration.py
@@ -1,0 +1,184 @@
+"""Tests for SH-147 PR B — face gate integration into carousel_reviewer.
+
+Verifies the additive hook in ``carousel_reviewer.check_built_post`` /
+``_run_face_gate_check``:
+- ``STORY_PIPELINE_V2_ENABLED=0`` (default) -> no face-gate issues appended
+- ``STORY_PIPELINE_V2_ENABLED=1`` -> face-gate violations appended as
+  ``[face-gate] slide N: Name — reason`` strings
+- unrouted/unknown niche -> silent skip, never raises
+- missing/unavailable gate module -> empty list (no crash)
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "content_creator"))
+
+# carousel_reviewer.py imports production deps (google-auth, google-api-python-client,
+# PIL, anthropic, openai, etc.) that aren't required to validate the face-gate
+# integration logic itself. CI runs with these installed (Python 3.11). Locally
+# we skip cleanly if any are missing so contributors can still iterate.
+try:
+    import carousel_reviewer as _reviewer  # noqa: E402
+    _REVIEWER_IMPORT_ERROR = None
+except Exception as _e:
+    _reviewer = None
+    _REVIEWER_IMPORT_ERROR = _e
+
+
+_SKIP_REASON = (
+    f"carousel_reviewer unavailable in this env: {_REVIEWER_IMPORT_ERROR!r}. "
+    "Tests will run in CI where production deps are installed."
+)
+
+
+def _content_with_named_person_no_face():
+    return {
+        "slides": [
+            {
+                "slide": 2,
+                "body_pt": "Segundo o senador <strong>Marcelo Castro</strong>, a CPI foi suspensa.",
+            }
+        ]
+    }
+
+
+def _content_with_named_person_and_sticker():
+    return {
+        "slides": [
+            {
+                "slide": 2,
+                "body_pt": "<strong>Marcelo Castro</strong> declarou hoje.",
+                "sticker_slot": "marcelo.png",
+            }
+        ]
+    }
+
+
+def _content_with_no_named_person():
+    return {
+        "slides": [
+            {"slide": 2, "body": "The concrete patio needs proper drainage."}
+        ]
+    }
+
+
+@unittest.skipIf(_reviewer is None, _SKIP_REASON)
+class FaceGateReviewerIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.reviewer = _reviewer
+
+    # --- flag OFF (default) -------------------------------------------------
+
+    def test_flag_off_returns_empty(self):
+        content = _content_with_named_person_no_face()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "0"}, clear=False):
+            issues = self.reviewer._run_face_gate_check(content, "brazil")
+        self.assertEqual(issues, [])
+
+    def test_flag_default_env_returns_empty(self):
+        content = _content_with_named_person_no_face()
+        env = {k: v for k, v in os.environ.items() if k != "STORY_PIPELINE_V2_ENABLED"}
+        with patch.dict(os.environ, env, clear=True):
+            issues = self.reviewer._run_face_gate_check(content, "brazil")
+        self.assertEqual(issues, [])
+
+    def test_flag_off_truthy_string_zero(self):
+        content = _content_with_named_person_no_face()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "false"}, clear=False):
+            issues = self.reviewer._run_face_gate_check(content, "brazil")
+        self.assertEqual(issues, [])
+
+    # --- flag ON ------------------------------------------------------------
+
+    def test_flag_on_appends_violation_string(self):
+        content = _content_with_named_person_no_face()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_face_gate_check(content, "brazil")
+        self.assertEqual(len(issues), 1)
+        self.assertTrue(issues[0].startswith("[face-gate] slide 2: Marcelo Castro"))
+
+    def test_flag_on_pass_when_face_present(self):
+        content = _content_with_named_person_and_sticker()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_face_gate_check(content, "brazil")
+        self.assertEqual(issues, [])
+
+    def test_flag_on_no_named_person_no_issues(self):
+        content = _content_with_no_named_person()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_face_gate_check(content, "opc")
+        self.assertEqual(issues, [])
+
+    def test_flag_on_truthy_values_all_enable(self):
+        content = _content_with_named_person_no_face()
+        for val in ("1", "true", "TRUE", "yes", "on"):
+            with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": val}, clear=False):
+                issues = self.reviewer._run_face_gate_check(content, "brazil")
+            self.assertEqual(len(issues), 1, f"value {val!r} should enable gate")
+
+    # --- niche filtering / safety -------------------------------------------
+
+    def test_unknown_niche_silently_skipped(self):
+        content = _content_with_named_person_no_face()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_face_gate_check(content, "stocks")
+        self.assertEqual(issues, [])
+
+    def test_empty_niche_silently_skipped(self):
+        content = _content_with_named_person_no_face()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_face_gate_check(content, "")
+        self.assertEqual(issues, [])
+
+    def test_none_content_does_not_crash(self):
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_face_gate_check(None, "opc")
+        # Either empty or a gate-failed marker, but must not raise.
+        self.assertIsInstance(issues, list)
+
+    def test_gate_module_unavailable_returns_empty(self):
+        # Simulate the gate module failing to import.
+        with patch.object(self.reviewer, "check_named_person_face_coverage", None):
+            content = _content_with_named_person_no_face()
+            with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+                issues = self.reviewer._run_face_gate_check(content, "brazil")
+            self.assertEqual(issues, [])
+
+    # --- integration via check_built_post ----------------------------------
+
+    def test_check_built_post_flag_off_no_face_gate_string(self):
+        """End-to-end: a built post result with a named-person-no-face content
+        should NOT produce [face-gate] issues when the flag is off."""
+        result = {
+            "post_id": "test-post-1",
+            "topic": "Test topic",
+            "niche": "brazil",
+            "content": _content_with_named_person_no_face(),
+        }
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "0", "WORK_DIR": "/nonexistent"}, clear=False):
+            out = self.reviewer.check_built_post(result)
+        face_gate_issues = [i for i in out["issues"] if "[face-gate]" in i]
+        self.assertEqual(face_gate_issues, [])
+
+    def test_check_built_post_flag_on_appends_face_gate_string(self):
+        result = {
+            "post_id": "test-post-2",
+            "topic": "Test topic",
+            "niche": "brazil",
+            "content": _content_with_named_person_no_face(),
+        }
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1", "WORK_DIR": "/nonexistent"}, clear=False):
+            out = self.reviewer.check_built_post(result)
+        face_gate_issues = [i for i in out["issues"] if "[face-gate]" in i]
+        self.assertEqual(len(face_gate_issues), 1)
+        self.assertIn("Marcelo Castro", face_gate_issues[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First **PR B** of the storytelling integration round. Wires the SH-147 named-person face gate (PR A merged in #165) into the post-build reviewer pipeline. Default flag-off = byte-identical reviewer output.

## What changed

`scripts/content_creator/carousel_reviewer.py`:
1. **Guarded import** (lines 46-55) — `try/except` around face-gate module so a syntax error in the gate can never break the reviewer
2. **New helper** `_run_face_gate_check(content, niche)` (lines 1033-1060) — single thin wrapper that:
   - returns `[]` if the gate module didn't import
   - returns `[]` if `STORY_PIPELINE_V2_ENABLED` is off (default)
   - returns `[]` if niche is unknown/empty (defensive)
   - returns one `[face-gate] slide N: Name — reason` string per violation
3. **Single-line call** inside `check_built_post()` (line 2384) right after the existing `check_news_template_dispatch` call. No restructuring of existing logic.

`scripts/tests/test_face_gate_reviewer_integration.py` (new):
- 13 unit tests covering flag-off/on, truthy variants (`1`/`true`/`yes`/`on`/`TRUE`), unknown niche, empty niche, None content, gate-module-missing path, end-to-end via `check_built_post` for both flag states
- Skips cleanly on environments where production deps (google-api-python-client, PIL, etc.) aren't installed — CI runs Python 3.11 with deps so they run fully

## Verified locally

```
$ python3.12 -m unittest scripts.tests.test_face_gate_reviewer_integration
Ran 13 tests in 0.003s
OK
```

(Python 3.12 venv with `pip install google-auth google-api-python-client pillow anthropic openai`)

## AIOX self-audit

- [x] Additive only — single new helper + 2-line call site
- [x] No touch to `build_html` / `process_one_topic` / `audit_post` (the 4 banned functions per SH-145 AIOX rules)
- [x] `check_built_post` touched ONLY to add the one `extend()` call — no restructuring
- [x] Flag default OFF -> byte-identical reviewer output
- [x] Guarded import (production import failure cannot crash reviewer)
- [x] Gate exceptions caught -> never leak as reviewer crash
- [x] No new external API calls, no LLM, no Drive I/O
- [x] Test count: PR A 17 unit tests + this PR 13 integration tests = 30 face-gate tests total

## Diff size

| File | + | - | Type |
|---|---|---|---|
| `scripts/content_creator/carousel_reviewer.py` | 41 | 0 | MODIFIED |
| `scripts/tests/test_face_gate_reviewer_integration.py` | 188 | 0 | ADDED |

## Note about local test skips

Local Python 3.9 (system Python) cannot import `carousel_reviewer.py` because the module uses PEP 604 `X | Y` type hints introduced in 3.10. CI runs Python 3.11 where they work. The integration tests use a `_REVIEWER_IMPORT_ERROR` skip guard so they SKIP cleanly when the import fails, rather than fail. Verified directly in Python 3.12 venv with prod deps installed (output above).

## Status

**DRAFT** -> awaiting AIOX audit + final diff sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)