### PR TITLE
SH-148 PR B: wire cadence gate into carousel_reviewer behind flag

### DIFF
--- a/scripts/content_creator/carousel_reviewer.py
+++ b/scripts/content_creator/carousel_reviewer.py
@@ -55,6 +55,16 @@ except Exception:
     check_named_person_face_coverage = None
     NamedPersonFaceGateError = Exception
 
+# SH-148 PR B — visual cadence gate. Same guarded-import pattern as SH-147.
+try:
+    from visual_cadence_gate import (
+        check_visual_cadence,
+        VisualCadenceGateError,
+    )
+except Exception:
+    check_visual_cadence = None
+    VisualCadenceGateError = Exception
+
 # Env vars
 SHEETS_TOKEN     = os.environ.get("SHEETS_TOKEN", "")
 ALERT_EMAIL      = os.environ.get("ALERT_EMAIL", "priscila@oakpark-construction.com")
@@ -1057,6 +1067,37 @@ def _run_face_gate_check(content: dict, niche: str) -> list[str]:
         return [f"[face-gate] gate failed with {type(exc).__name__}: {exc}"]
     return [
         f"[face-gate] slide {v.slide_index}: {v.person_name} — {v.reason}"
+        for v in violations
+    ]
+
+
+def _run_cadence_gate_check(content: dict, niche: str) -> list[str]:
+    """SH-148 PR B integration — visual cadence gate review hook.
+
+    Flag-gated by ``STORY_PIPELINE_V2_ENABLED``. Default OFF means this
+    returns an empty list and the reviewer is byte-identical to pre-PR-B.
+
+    When ON, scans the content dict's ``slides`` for 2+ consecutive
+    ``visual_hint == "none"`` middle slides (cover and sources exempt).
+    Returns one issue string per offending run, prefixed ``[cadence-gate]``
+    so review emails and tracker rows can grep it.
+    """
+    if check_visual_cadence is None:
+        return []
+    flag = str(os.environ.get("STORY_PIPELINE_V2_ENABLED", "0")).strip().lower()
+    if flag not in {"1", "true", "yes", "on"}:
+        return []
+    if niche not in ("opc", "brazil", "usa", "news"):
+        return []
+    try:
+        violations = check_visual_cadence(content or {}, route=niche)
+    except VisualCadenceGateError:
+        # Unrouted/unknown route — silent skip, never break the reviewer.
+        return []
+    except Exception as exc:  # pragma: no cover - defensive
+        return [f"[cadence-gate] gate failed with {type(exc).__name__}: {exc}"]
+    return [
+        f"[cadence-gate] slides {v.start_slide_index}-{v.end_slide_index}: {v.reason}"
         for v in violations
     ]
 
@@ -2382,6 +2423,8 @@ def check_built_post(result: dict) -> dict:
     all_issues.extend(check_news_template_dispatch(_content_dict, niche))
     # SH-147 PR B — face gate. No-op when STORY_PIPELINE_V2_ENABLED is off.
     all_issues.extend(_run_face_gate_check(_content_dict, niche))
+    # SH-148 PR B — visual cadence gate. No-op when STORY_PIPELINE_V2_ENABLED is off.
+    all_issues.extend(_run_cadence_gate_check(_content_dict, niche))
 
     # 0. Phase 5 — smart slide-plan gates (Phase 4 picker output validation).
     # Runs FIRST so a hallucinated/banned plan blocks the post before any

--- a/scripts/tests/test_cadence_gate_reviewer_integration.py
+++ b/scripts/tests/test_cadence_gate_reviewer_integration.py
@@ -1,0 +1,184 @@
+"""Tests for SH-148 PR B — cadence gate integration into carousel_reviewer.
+
+Verifies the additive hook in ``carousel_reviewer.check_built_post`` /
+``_run_cadence_gate_check``:
+- ``STORY_PIPELINE_V2_ENABLED=0`` (default) -> no cadence-gate issues appended
+- ``STORY_PIPELINE_V2_ENABLED=1`` -> cadence violations appended as
+  ``[cadence-gate] slides A-B: reason`` strings
+- unrouted/unknown niche -> silent skip, never raises
+- missing/unavailable gate module -> empty list (no crash)
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "content_creator"))
+
+# Same skip-on-import-fail pattern as SH-147 PR B test. CI (Python 3.11)
+# imports cleanly; local Python 3.9 with no google deps will skip.
+try:
+    import carousel_reviewer as _reviewer  # noqa: E402
+    _REVIEWER_IMPORT_ERROR = None
+except Exception as _e:
+    _reviewer = None
+    _REVIEWER_IMPORT_ERROR = _e
+
+
+_SKIP_REASON = (
+    f"carousel_reviewer unavailable in this env: {_REVIEWER_IMPORT_ERROR!r}. "
+    "Tests will run in CI where production deps are installed."
+)
+
+
+def _slide(slide_num, **fields):
+    base = {"slide": slide_num}
+    base.update(fields)
+    return base
+
+
+def _content_with_two_consecutive_text_only():
+    return {
+        "slides": [
+            _slide(1, type="cover"),
+            _slide(2, visual_hint="none"),
+            _slide(3, visual_hint="none"),
+            _slide(4, visual_hint="product-photo"),
+            _slide(5, slide_purpose="sources"),
+        ]
+    }
+
+
+def _content_with_three_consecutive_text_only():
+    return {
+        "slides": [
+            _slide(1, type="cover"),
+            _slide(2, visual_hint="none"),
+            _slide(3, visual_hint="none"),
+            _slide(4, visual_hint="none"),
+            _slide(5, slide_purpose="sources"),
+        ]
+    }
+
+
+def _content_clean_cadence():
+    return {
+        "slides": [
+            _slide(1, type="cover"),
+            _slide(2, visual_hint="product-photo"),
+            _slide(3, visual_hint="none"),
+            _slide(4, visual_hint="context-image"),
+            _slide(5, slide_purpose="sources"),
+        ]
+    }
+
+
+@unittest.skipIf(_reviewer is None, _SKIP_REASON)
+class CadenceGateReviewerIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.reviewer = _reviewer
+
+    # --- flag OFF (default) -------------------------------------------------
+
+    def test_flag_off_returns_empty(self):
+        content = _content_with_two_consecutive_text_only()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "0"}, clear=False):
+            issues = self.reviewer._run_cadence_gate_check(content, "opc")
+        self.assertEqual(issues, [])
+
+    def test_flag_default_env_returns_empty(self):
+        content = _content_with_two_consecutive_text_only()
+        env = {k: v for k, v in os.environ.items() if k != "STORY_PIPELINE_V2_ENABLED"}
+        with patch.dict(os.environ, env, clear=True):
+            issues = self.reviewer._run_cadence_gate_check(content, "opc")
+        self.assertEqual(issues, [])
+
+    # --- flag ON ------------------------------------------------------------
+
+    def test_flag_on_two_consecutive_emits_violation(self):
+        content = _content_with_two_consecutive_text_only()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_cadence_gate_check(content, "opc")
+        self.assertEqual(len(issues), 1)
+        self.assertTrue(issues[0].startswith("[cadence-gate] slides 2-3:"))
+
+    def test_flag_on_three_consecutive_emits_violation(self):
+        content = _content_with_three_consecutive_text_only()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_cadence_gate_check(content, "brazil")
+        self.assertEqual(len(issues), 1)
+        self.assertTrue(issues[0].startswith("[cadence-gate] slides 2-4:"))
+
+    def test_flag_on_clean_cadence_no_issues(self):
+        content = _content_clean_cadence()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_cadence_gate_check(content, "opc")
+        self.assertEqual(issues, [])
+
+    def test_flag_on_truthy_values_all_enable(self):
+        content = _content_with_two_consecutive_text_only()
+        for val in ("1", "true", "TRUE", "yes", "on"):
+            with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": val}, clear=False):
+                issues = self.reviewer._run_cadence_gate_check(content, "opc")
+            self.assertEqual(len(issues), 1, f"value {val!r} should enable gate")
+
+    # --- niche filtering / safety -------------------------------------------
+
+    def test_unknown_niche_silently_skipped(self):
+        content = _content_with_two_consecutive_text_only()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_cadence_gate_check(content, "stocks")
+        self.assertEqual(issues, [])
+
+    def test_empty_niche_silently_skipped(self):
+        content = _content_with_two_consecutive_text_only()
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_cadence_gate_check(content, "")
+        self.assertEqual(issues, [])
+
+    def test_none_content_does_not_crash(self):
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+            issues = self.reviewer._run_cadence_gate_check(None, "opc")
+        self.assertIsInstance(issues, list)
+
+    def test_gate_module_unavailable_returns_empty(self):
+        with patch.object(self.reviewer, "check_visual_cadence", None):
+            content = _content_with_two_consecutive_text_only()
+            with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1"}, clear=False):
+                issues = self.reviewer._run_cadence_gate_check(content, "opc")
+            self.assertEqual(issues, [])
+
+    # --- integration via check_built_post ----------------------------------
+
+    def test_check_built_post_flag_off_no_cadence_gate_string(self):
+        result = {
+            "post_id": "test-cadence-1",
+            "topic": "Test topic",
+            "niche": "opc",
+            "content": _content_with_two_consecutive_text_only(),
+        }
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "0", "WORK_DIR": "/nonexistent"}, clear=False):
+            out = self.reviewer.check_built_post(result)
+        cadence_issues = [i for i in out["issues"] if "[cadence-gate]" in i]
+        self.assertEqual(cadence_issues, [])
+
+    def test_check_built_post_flag_on_appends_cadence_gate_string(self):
+        result = {
+            "post_id": "test-cadence-2",
+            "topic": "Test topic",
+            "niche": "brazil",
+            "content": _content_with_three_consecutive_text_only(),
+        }
+        with patch.dict(os.environ, {"STORY_PIPELINE_V2_ENABLED": "1", "WORK_DIR": "/nonexistent"}, clear=False):
+            out = self.reviewer.check_built_post(result)
+        cadence_issues = [i for i in out["issues"] if "[cadence-gate]" in i]
+        self.assertEqual(len(cadence_issues), 1)
+        self.assertIn("slides 2-4", cadence_issues[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Second PR B of the storytelling integration round. Wires the SH-148 visual cadence gate (PR A merged in #166) into the post-build reviewer pipeline. Default flag-off = byte-identical reviewer output.

**Mirrors SH-147 PR B (#169) exactly** — same guarded-import pattern, same flag check, same 3-layer early-return, same try/except defensiveness. The audit Priscila ran on #169 applies to this PR step-for-step.

## What changed

`scripts/content_creator/carousel_reviewer.py`:
1. Guarded import of `visual_cadence_gate` module (try/except, sibling to the SH-147 face-gate import already landed in #169)
2. New helper `_run_cadence_gate_check(content, niche)` — same shape as `_run_face_gate_check`:
   - returns `[]` if the gate module is unavailable
   - returns `[]` if `STORY_PIPELINE_V2_ENABLED` is off (default)
   - returns `[]` if niche is unknown (defensive)
   - returns one `[cadence-gate] slides A-B: reason` string per run of 2+ consecutive text-only middle slides
3. Single-line call inside `check_built_post()` right after the SH-147 face-gate call

`scripts/tests/test_cadence_gate_reviewer_integration.py` (new):
- 12 unit tests covering flag-off/on, 2-vs-3 consecutive text-only runs, clean cadence, truthy variants, unknown niche, empty niche, None content, gate-module-missing path, end-to-end via `check_built_post` for both flag states
- Same skip-on-import-fail pattern as SH-147 PR B test (production deps via google-api-python-client/PIL/anthropic/openai required; CI Python 3.11 has them)

## Verified

```
$ /tmp/sh147-venv/bin/python -m unittest \
    scripts.tests.test_cadence_gate_reviewer_integration \
    scripts.tests.test_face_gate_reviewer_integration
Ran 25 tests OK
```

## Diff size

| File | + | - | Type |
|---|---|---|---|
| `scripts/content_creator/carousel_reviewer.py` | 43 | 0 | MODIFIED |
| `scripts/tests/test_cadence_gate_reviewer_integration.py` | 184 | 0 | ADDED |

## AIOX self-audit (same checklist as SH-147 PR B)

- [x] Additive only — single new helper + 2-line call site
- [x] No touch to `build_html` / `process_one_topic` / `audit_post`
- [x] `check_built_post` touched ONLY to add the comment + extend() call
- [x] Flag default OFF -> byte-identical reviewer output
- [x] Guarded import + module-missing/flag-off/niche-unknown early returns
- [x] Gate exceptions wrapped -> never crash reviewer
- [x] Issue prefix stable: `[cadence-gate]` (sibling to `[face-gate]`)
- [x] No new external API calls, no LLM, no Drive I/O

## Process notes

Branch hijack incident during this PR (parallel CLAUDE.md compression work checked me back to main mid-edit). Recovered by cherry-picking the commit onto the right branch + resetting local main. PR diff is clean. **Lesson reinforced**: commit immediately after every Edit when touching production files; verify branch state before every push.

## Status

**DRAFT** -> awaiting AIOX audit + final 8-item verification (same checklist Priscila used for #169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)