### PR TITLE
Bake: enable storytelling V2 reviewer gates for Brazil-only

### DIFF
--- a/.github/workflows/content_creator.yml
+++ b/.github/workflows/content_creator.yml
@@ -190,6 +190,13 @@ jobs:
       # Spec: doc 1BDg9ORggVsWH-WQPBx4iQnYNu2UA5vHWcuNRkXCY5v8 (v3 FINAL).
       # OPC purposes: hook|cost|teach|apply|sources. News purposes: claim|number|evidence|opposition|implication|sources.
       SLIDE_PURPOSE_PILOT: ${{ github.event.inputs.slide_purpose_pilot || '0' }}
+      # BAKE 2026-05-25 — storytelling V2 reviewer gates (SH-145..151).
+      # ENABLED=1 turns on face/cadence/motion-static/news-source-advisory gates.
+      # NICHES=brazil scopes the bake so only Brazil posts participate; OPC + USA
+      # stay byte-identical. Expand to "brazil,usa" or "brazil,usa,opc" after bake.
+      # Rollback: set ENABLED to '0' (one-line revert).
+      STORY_PIPELINE_V2_ENABLED: '1'
+      STORY_PIPELINE_V2_NICHES: 'brazil'
       CAPTURE_STORY_ID: ${{ github.event.inputs.capture_story_id || '' }}
 
     steps:
@@ -401,6 +408,13 @@ jobs:
       # Spec: doc 1BDg9ORggVsWH-WQPBx4iQnYNu2UA5vHWcuNRkXCY5v8 (v3 FINAL).
       # OPC purposes: hook|cost|teach|apply|sources. News purposes: claim|number|evidence|opposition|implication|sources.
       SLIDE_PURPOSE_PILOT: ${{ github.event.inputs.slide_purpose_pilot || '0' }}
+      # BAKE 2026-05-25 — storytelling V2 reviewer gates (SH-145..151).
+      # ENABLED=1 turns on face/cadence/motion-static/news-source-advisory gates.
+      # NICHES=brazil scopes the bake so only Brazil posts participate; OPC + USA
+      # stay byte-identical. Expand to "brazil,usa" or "brazil,usa,opc" after bake.
+      # Rollback: set ENABLED to '0' (one-line revert).
+      STORY_PIPELINE_V2_ENABLED: '1'
+      STORY_PIPELINE_V2_NICHES: 'brazil'
       CAPTURE_STORY_ID: ${{ github.event.inputs.capture_story_id || '' }}
 
     steps:

--- a/scripts/content_creator/carousel_reviewer.py
+++ b/scripts/content_creator/carousel_reviewer.py
@@ -1061,6 +1061,30 @@ def check_opc_professional_ethics(content: dict) -> list[str]:
     return issues
 
 
+def _storytelling_gate_in_scope(niche: str) -> bool:
+    """Bake-control helper — return False when a gate should sit out this niche.
+
+    Reads two env vars:
+    - ``STORY_PIPELINE_V2_ENABLED`` — master flag (default OFF)
+    - ``STORY_PIPELINE_V2_NICHES`` — optional comma-separated allowlist.
+      Empty / unset => apply to all supported niches (legacy behavior).
+      Set => only niches in the list participate. Example: ``"brazil"`` for
+      a Brazil-only bake; ``"brazil,usa"`` to expand later.
+
+    Used by all 4 storytelling gate hooks so a single env-var change can
+    scope the bake without touching gate code. Returns False if the master
+    flag is off OR if the niche scope excludes ``niche``.
+    """
+    flag = str(os.environ.get("STORY_PIPELINE_V2_ENABLED", "0")).strip().lower()
+    if flag not in {"1", "true", "yes", "on"}:
+        return False
+    scope_raw = str(os.environ.get("STORY_PIPELINE_V2_NICHES", "")).strip()
+    if not scope_raw:
+        return True  # unset = all niches in scope
+    scope = {n.strip().lower() for n in scope_raw.split(",") if n.strip()}
+    return (niche or "").strip().lower() in scope
+
+
 def _run_face_gate_check(content: dict, niche: str) -> list[str]:
     """SH-147 PR B integration — named-person face gate review hook.
 
@@ -1074,8 +1098,7 @@ def _run_face_gate_check(content: dict, niche: str) -> list[str]:
     """
     if check_named_person_face_coverage is None:
         return []
-    flag = str(os.environ.get("STORY_PIPELINE_V2_ENABLED", "0")).strip().lower()
-    if flag not in {"1", "true", "yes", "on"}:
+    if not _storytelling_gate_in_scope(niche):
         return []
     if niche not in ("opc", "brazil", "usa", "news"):
         return []
@@ -1105,8 +1128,7 @@ def _run_cadence_gate_check(content: dict, niche: str) -> list[str]:
     """
     if check_visual_cadence is None:
         return []
-    flag = str(os.environ.get("STORY_PIPELINE_V2_ENABLED", "0")).strip().lower()
-    if flag not in {"1", "true", "yes", "on"}:
+    if not _storytelling_gate_in_scope(niche):
         return []
     if niche not in ("opc", "brazil", "usa", "news"):
         return []
@@ -1135,8 +1157,7 @@ def _run_news_source_dual_gate_advisory(content: dict, niche: str) -> list[str]:
     """
     if check_news_source_dual_gate is None:
         return []
-    flag = str(os.environ.get("STORY_PIPELINE_V2_ENABLED", "0")).strip().lower()
-    if flag not in {"1", "true", "yes", "on"}:
+    if not _storytelling_gate_in_scope(niche):
         return []
     if niche not in ("brazil", "usa", "news"):
         return []
@@ -1171,8 +1192,7 @@ def _run_motion_static_gate_check(
     """
     if check_motion_static_siblings is None:
         return []
-    flag = str(os.environ.get("STORY_PIPELINE_V2_ENABLED", "0")).strip().lower()
-    if flag not in {"1", "true", "yes", "on"}:
+    if not _storytelling_gate_in_scope(niche):
         return []
     if niche not in ("opc", "brazil", "usa", "news"):
         return []

--- a/scripts/tests/test_storytelling_gate_scope.py
+++ b/scripts/tests/test_storytelling_gate_scope.py
@@ -1,0 +1,213 @@
+"""Tests for the STORY_PIPELINE_V2_NICHES bake-control scope helper.
+
+Verifies ``carousel_reviewer._storytelling_gate_in_scope`` and that the
+scope check is honored by all 4 storytelling gate hooks (face, cadence,
+news source dual-gate, motion/static).
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "content_creator"))
+
+try:
+    import carousel_reviewer as _reviewer  # noqa: E402
+    _REVIEWER_IMPORT_ERROR = None
+except Exception as _e:
+    _reviewer = None
+    _REVIEWER_IMPORT_ERROR = _e
+
+
+_SKIP_REASON = (
+    f"carousel_reviewer unavailable in this env: {_REVIEWER_IMPORT_ERROR!r}. "
+    "Tests will run in CI where production deps are installed."
+)
+
+
+@unittest.skipIf(_reviewer is None, _SKIP_REASON)
+class StorytellingGateScopeTest(unittest.TestCase):
+    """Direct tests of _storytelling_gate_in_scope()."""
+
+    def test_flag_off_returns_false_regardless_of_scope(self):
+        for scope in ("", "brazil", "brazil,usa", "all"):
+            with patch.dict(os.environ, {
+                "STORY_PIPELINE_V2_ENABLED": "0",
+                "STORY_PIPELINE_V2_NICHES": scope,
+            }, clear=False):
+                self.assertFalse(_reviewer._storytelling_gate_in_scope("brazil"))
+
+    def test_flag_default_env_returns_false(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("STORY_PIPELINE_V2_ENABLED", "STORY_PIPELINE_V2_NICHES")}
+        with patch.dict(os.environ, env, clear=True):
+            self.assertFalse(_reviewer._storytelling_gate_in_scope("brazil"))
+
+    def test_flag_on_no_scope_means_all_niches_in_scope(self):
+        env = {k: v for k, v in os.environ.items() if k != "STORY_PIPELINE_V2_NICHES"}
+        env["STORY_PIPELINE_V2_ENABLED"] = "1"
+        with patch.dict(os.environ, env, clear=True):
+            for niche in ("brazil", "usa", "opc", "news", "anything"):
+                self.assertTrue(_reviewer._storytelling_gate_in_scope(niche), f"niche={niche!r}")
+
+    def test_flag_on_empty_scope_means_all_niches(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "",
+        }, clear=False):
+            for niche in ("brazil", "usa", "opc", "news"):
+                self.assertTrue(_reviewer._storytelling_gate_in_scope(niche))
+
+    def test_scope_brazil_only_includes_brazil(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            self.assertTrue(_reviewer._storytelling_gate_in_scope("brazil"))
+
+    def test_scope_brazil_only_excludes_opc_and_usa(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            self.assertFalse(_reviewer._storytelling_gate_in_scope("opc"))
+            self.assertFalse(_reviewer._storytelling_gate_in_scope("usa"))
+            self.assertFalse(_reviewer._storytelling_gate_in_scope("news"))
+
+    def test_scope_multi_niche_csv(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil,usa",
+        }, clear=False):
+            self.assertTrue(_reviewer._storytelling_gate_in_scope("brazil"))
+            self.assertTrue(_reviewer._storytelling_gate_in_scope("usa"))
+            self.assertFalse(_reviewer._storytelling_gate_in_scope("opc"))
+
+    def test_scope_case_insensitive(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "BRAZIL, USA",
+        }, clear=False):
+            self.assertTrue(_reviewer._storytelling_gate_in_scope("brazil"))
+            self.assertTrue(_reviewer._storytelling_gate_in_scope("Brazil"))
+            self.assertTrue(_reviewer._storytelling_gate_in_scope("usa"))
+
+    def test_scope_with_whitespace_and_empty_entries(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": " brazil , , usa ,",
+        }, clear=False):
+            self.assertTrue(_reviewer._storytelling_gate_in_scope("brazil"))
+            self.assertTrue(_reviewer._storytelling_gate_in_scope("usa"))
+            self.assertFalse(_reviewer._storytelling_gate_in_scope("opc"))
+
+    def test_empty_niche_with_scope_returns_false(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            self.assertFalse(_reviewer._storytelling_gate_in_scope(""))
+            self.assertFalse(_reviewer._storytelling_gate_in_scope(None))
+
+
+@unittest.skipIf(_reviewer is None, _SKIP_REASON)
+class GateHooksHonorScopeTest(unittest.TestCase):
+    """Verifies all 4 gate hooks return [] when niche is out of scope,
+    even though the master flag is ON and the niche is in the gate's
+    supported list."""
+
+    def _named_no_face(self):
+        return {
+            "slides": [{
+                "slide": 2,
+                "body_pt": "Segundo <strong>Marcelo Castro</strong>, ...",
+            }]
+        }
+
+    def _bad_cadence(self):
+        return {
+            "slides": [
+                {"slide": 1, "type": "cover"},
+                {"slide": 2, "visual_hint": "none"},
+                {"slide": 3, "visual_hint": "none"},
+                {"slide": 4, "slide_purpose": "sources"},
+            ]
+        }
+
+    def _single_source_confirmed(self):
+        return {"claims": [{"text": "x", "status": "confirmed", "sources": ["G1"]}]}
+
+    def test_face_gate_skips_when_opc_out_of_scope(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            issues = _reviewer._run_face_gate_check(self._named_no_face(), "opc")
+        self.assertEqual(issues, [])
+
+    def test_face_gate_fires_when_brazil_in_scope(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            issues = _reviewer._run_face_gate_check(self._named_no_face(), "brazil")
+        self.assertEqual(len(issues), 1)
+        self.assertIn("Marcelo Castro", issues[0])
+
+    def test_cadence_gate_skips_when_opc_out_of_scope(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            issues = _reviewer._run_cadence_gate_check(self._bad_cadence(), "opc")
+        self.assertEqual(issues, [])
+
+    def test_news_source_advisory_skips_when_opc_out_of_scope(self):
+        # opc is already not in the news-source niche list — but this still
+        # verifies the scope check fires before the niche-list check
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            issues = _reviewer._run_news_source_dual_gate_advisory(
+                self._single_source_confirmed(), "usa"
+            )
+        # usa is in gate's niche list but NOT in scope -> empty
+        self.assertEqual(issues, [])
+
+    def test_news_source_advisory_fires_when_brazil_in_scope(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            issues = _reviewer._run_news_source_dual_gate_advisory(
+                self._single_source_confirmed(), "brazil"
+            )
+        self.assertGreaterEqual(len(issues), 1)
+
+    def test_motion_static_gate_skips_when_opc_out_of_scope(self):
+        with patch.dict(os.environ, {
+            "STORY_PIPELINE_V2_ENABLED": "1",
+            "STORY_PIPELINE_V2_NICHES": "brazil",
+        }, clear=False):
+            issues = _reviewer._run_motion_static_gate_check(
+                {}, "opc", "some-post", "/nonexistent"
+            )
+        self.assertEqual(issues, [])
+
+    def test_legacy_unset_scope_keeps_all_niches_enabled(self):
+        """Sanity: existing prod-style flag with no NICHES var = all niches gated."""
+        env = {k: v for k, v in os.environ.items() if k != "STORY_PIPELINE_V2_NICHES"}
+        env["STORY_PIPELINE_V2_ENABLED"] = "1"
+        with patch.dict(os.environ, env, clear=True):
+            for niche in ("opc", "brazil", "usa"):
+                issues = _reviewer._run_face_gate_check(self._named_no_face(), niche)
+                self.assertEqual(len(issues), 1, f"niche={niche!r}: expected face gate to fire")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**BAKE START** — turns on the 4 storytelling V2 reviewer gates (SH-147/148/149/151) for **Brazil posts only**. OPC + USA stay byte-identical to current production. Single-commit rollback.

This PR has 2 commits:
1. **Commit A — `bake-prep`**: Adds the `STORY_PIPELINE_V2_NICHES` scope helper. Backward-compatible (when NICHES is unset, behavior is identical to today). Pure additive code change.
2. **Commit B — `bake`**: Flips `STORY_PIPELINE_V2_ENABLED='1'` + `STORY_PIPELINE_V2_NICHES='brazil'` in both jobs of `content_creator.yml`. The actual bake start.

## What happens after merge

### Brazil posts (next nightly + every manual trigger)
- `[face-gate]` — named person without face treatment → **blocks** the post (`passed=False`)
- `[cadence-gate]` — 2+ consecutive text-only middle slides → **blocks**
- `[motion-static-gate]` — missing motion artifacts → **blocks**
- `[news-source-gate][advisory]` — single-source confirmed claims or `@marceloem23` citations → **advisory only** (shows ℹ in email, does NOT block)

### OPC + USA posts
- **Byte-identical to today.** The scope filter (`STORY_PIPELINE_V2_NICHES='brazil'`) silently skips all 4 gate hooks for these niches.

## Verification

```
$ /tmp/sh147-venv/bin/python -m unittest \
    scripts.tests.test_face_gate_reviewer_integration \
    scripts.tests.test_cadence_gate_reviewer_integration \
    scripts.tests.test_news_source_dual_gate_reviewer_integration \
    scripts.tests.test_motion_static_gate_reviewer_integration \
    scripts.tests.test_storytelling_gate_scope
Ran 70 tests in 0.079s
OK
```

17 new tests cover:
- `_storytelling_gate_in_scope()` directly (10 cases)
- All 4 gate hooks honor the scope (7 cases including legacy "no scope = all niches")

## Files

| File | + | - | Type |
|---|---|---|---|
| `scripts/content_creator/carousel_reviewer.py` | 23 | 8 | MODIFIED (new helper + 4 call-site updates) |
| `scripts/tests/test_storytelling_gate_scope.py` | 218 | 0 | ADDED |
| `.github/workflows/content_creator.yml` | 14 | 0 | MODIFIED (env vars in both jobs) |

## How we'll know the bake worked

### Daily checklist (morning, ~5 min)
1. Open the nightly review email
2. Grep for `[face-gate]` / `[cadence-gate]` / `[motion-static-gate]` / `[news-source-gate][advisory]`
3. For each tag, decide: **true positive (real problem) or false positive (gate fired but the post is fine)**
4. Note any `[gate] gate failed with ...` — that's a crash signal

### Targets (end of week 1)
- ≥70% true-positive rate per gate
- ≤2 false positives per week per gate
- Zero gate-crash strings

### Decision after 5-7 days
- All green → expand `STORY_PIPELINE_V2_NICHES` to `'brazil,usa'`, then later `'brazil,usa,opc'`. Promote news source advisory → block.
- Gate too strict (FP) → tune threshold in gate module + ship a follow-up PR.
- Gate crashes → flip `STORY_PIPELINE_V2_ENABLED='0'` immediately (1-line revert in workflow), fix in follow-up PR.

## Rollback

Set `STORY_PIPELINE_V2_ENABLED: '1'` → `'0'` in both env blocks of `content_creator.yml`. Next run is byte-identical to pre-bake. No data loss.

## AIOX

- [x] Commit A is additive — legacy behavior preserved when NICHES unset
- [x] Commit B is a workflow flag flip — instant 1-line rollback
- [x] No touch to `build_html` / `process_one_topic` / `audit_post` (already-landed gate call sites only)
- [x] OPC + USA: zero production change, zero risk
- [x] Brazil: gates fire as designed, advisory news source can't block posts

## Status

**DRAFT** -> awaiting your audit + green light to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)