### PR TITLE
FORMAT-025: Before The Cut — dual-video debunk reel (Phase 1 manual MVP)

### DIFF
--- a/.github/workflows/render-beforethecut.yml
+++ b/.github/workflows/render-beforethecut.yml
@@ -1,0 +1,337 @@
+name: Render Video — Before The Cut (FORMAT-025)
+# Renders the FORMAT-025 deceptive-edit debunk reel (dual-video split) via Remotion.
+# MANUAL MVP: the original clip is sourced by hand (you supply original_url + window).
+# The AUTO original-clip-finder is a separate Phase-2 build — NOT wired here yet.
+# ALWAYS triggered manually via workflow_dispatch.
+#
+# Inputs you supply by hand (manual sourcing):
+#   - the manipulated cut is the captured reel already in News/{project}/Captures ({story_id}_original.mp4)
+#   - original_url + window_start/window_end = the uncut original, windowed to the moment + the seconds BEFORE
+#
+# Devops-audited (Gage, FORMAT-025_BUILD_SPEC.md): --concurrency=2, swap space,
+# yt-dlp --download-sections (window only), routing.reels_folder dest, failure logging.
+
+on:
+  workflow_dispatch:
+    inputs:
+      story_id:
+        description: 'Story ID of the captured manipulated reel (e.g. NWS-202606091200)'
+        required: true
+      project:
+        description: 'brazil or usa — which Captures folder + Reels destination'
+        required: false
+        default: 'brazil'
+        type: choice
+        options:
+          - brazil
+          - usa
+      original_url:
+        description: 'URL of the UNCUT original (YouTube / TV Câmara / TV Senado / C-SPAN channel preferred)'
+        required: true
+      window_start:
+        description: 'Start of the download window HH:MM:SS — set this a few seconds BEFORE the cut (this is the "before" context)'
+        required: true
+      window_end:
+        description: 'End of the download window HH:MM:SS'
+        required: true
+      reveal_frame:
+        description: 'Frame when the split appears (default 150 = 5s, after the hook)'
+        required: false
+        default: '150'
+      total_frames:
+        description: 'Total reel duration in frames at 30fps (default 900 = 30s)'
+        required: false
+        default: '900'
+      hook_pt:
+        description: 'PT hook (first 5s). e.g. "Cortaram o começo deste vídeo."'
+        required: false
+        default: 'Cortaram o começo deste vídeo.'
+      hook_en:
+        description: 'EN hook (first 5s). e.g. "They cut the start of this video."'
+        required: false
+        default: 'They cut the start of this video.'
+      context_text_pt:
+        description: 'PT context band — what they were ACTUALLY talking about'
+        required: false
+        default: ''
+      context_text_en:
+        description: 'EN context band — what they were ACTUALLY talking about'
+        required: false
+        default: ''
+      source_label:
+        description: 'Source credit shown bottom strip, e.g. "Fonte: TV Câmara — 14:32"'
+        required: false
+        default: ''
+      creator_handle:
+        description: 'Handle that posted the manipulated cut (shown on phase-1 chip)'
+        required: false
+        default: ''
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'  # Remotion 4.x requires Node 20+
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install google-auth google-auth-httplib2 google-api-python-client requests yt-dlp
+
+      # Gage devops change #1 — swap insurance for dual-video decode.
+      - name: Add swap space (8GB)
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+
+      - name: Write Google credentials
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+        run: |
+          mkdir -p /tmp/creds
+          echo "$SHEETS_TOKEN" > /tmp/creds/sheets_token.json
+
+      - name: Write YouTube cookies (for yt-dlp on parliament/YouTube feeds)
+        env:
+          YT_COOKIES: ${{ secrets.PRI_OP_YT_COOKIES }}
+        run: |
+          if [ -n "$YT_COOKIES" ]; then
+            echo "$YT_COOKIES" > /tmp/yt_cookies.txt
+            echo "cookies written"
+          else
+            echo "no PRI_OP_YT_COOKIES set — yt-dlp will try anonymous"
+          fi
+
+      - name: Download manipulated cut from News Drive Captures
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+          STORY_ID: ${{ github.event.inputs.story_id }}
+          PROJECT: ${{ github.event.inputs.project }}
+        run: |
+          mkdir -p scripts/remotion/public
+          python3 - << 'PYEOF'
+          import json, os, io, sys
+          from google.oauth2.credentials import Credentials
+          from googleapiclient.discovery import build
+          from googleapiclient.http import MediaIoBaseDownload
+
+          story_id = os.environ["STORY_ID"]
+          token_data = json.loads(os.environ["SHEETS_TOKEN"])
+          creds = Credentials(
+              token=token_data.get("token"),
+              refresh_token=token_data.get("refresh_token"),
+              token_uri=token_data.get("token_uri", "https://oauth2.googleapis.com/token"),
+              client_id=token_data.get("client_id"),
+              client_secret=token_data.get("client_secret"),
+          )
+          drive = build("drive", "v3", credentials=creds)
+          # Resolve Captures folder from routing.py (single source of truth)
+          sys.path.insert(0, "scripts")
+          from routing import get_route
+          project = os.environ["PROJECT"].lower()
+          capture_folder = get_route(project)["capture_folder_id"]
+
+          dest = "scripts/remotion/public/manipulated.mp4"
+          results = drive.files().list(
+              q=f"name='{story_id}_original.mp4' and '{capture_folder}' in parents and trashed=false",
+              supportsAllDrives=True, includeItemsFromAllDrives=True,
+              fields="files(id,name,size)",
+          ).execute()
+          files = results.get("files", [])
+          if not files:
+              print(f"ERROR: {story_id}_original.mp4 not found in Captures folder {capture_folder}")
+              sys.exit(1)
+          fid = files[0]["id"]
+          req = drive.files().get_media(fileId=fid, supportsAllDrives=True)
+          buf = io.FileIO(dest, "wb")
+          dl = MediaIoBaseDownload(buf, req)
+          done = False
+          while not done:
+              _, done = dl.next_chunk()
+          buf.close()
+          print(f"  Downloaded manipulated cut → {dest} ({os.path.getsize(dest)/1024/1024:.1f} MB)")
+          PYEOF
+
+      # Gage devops change #2 — window-only download. NEVER pull the full (hours-long) original.
+      - name: Download UNCUT original window via yt-dlp (--download-sections)
+        env:
+          ORIGINAL_URL: ${{ github.event.inputs.original_url }}
+          WINDOW_START: ${{ github.event.inputs.window_start }}
+          WINDOW_END: ${{ github.event.inputs.window_end }}
+        run: |
+          COOKIE_ARG=""
+          [ -f /tmp/yt_cookies.txt ] && COOKIE_ARG="--cookies /tmp/yt_cookies.txt"
+          yt-dlp $COOKIE_ARG \
+            --download-sections "*${WINDOW_START}-${WINDOW_END}" \
+            --force-keyframes-at-cuts \
+            -f "bestvideo[height<=1080]+bestaudio/best[height<=1080]" \
+            --merge-output-format mp4 \
+            -o "scripts/remotion/public/original.mp4" \
+            "$ORIGINAL_URL"
+          ls -lh scripts/remotion/public/original.mp4
+          [ -f scripts/remotion/public/original.mp4 ] || { echo "ERROR: original window not downloaded"; exit 1; }
+
+      - name: Install Remotion dependencies
+        working-directory: scripts/remotion
+        run: npm install
+
+      - name: Build render props JSON (EN)
+        env:
+          STORY_ID: ${{ github.event.inputs.story_id }}
+          REVEAL_FRAME: ${{ github.event.inputs.reveal_frame }}
+          TOTAL_FRAMES: ${{ github.event.inputs.total_frames }}
+          HOOK_EN: ${{ github.event.inputs.hook_en }}
+          CONTEXT_EN: ${{ github.event.inputs.context_text_en }}
+          SOURCE_LABEL: ${{ github.event.inputs.source_label }}
+          CREATOR_HANDLE: ${{ github.event.inputs.creator_handle }}
+        run: |
+          python3 scripts/remotion/build_beforethecut_props.py \
+            --story-id "$STORY_ID" --language en \
+            --reveal-frame "$REVEAL_FRAME" --total-frames "$TOTAL_FRAMES" \
+            --hook "$HOOK_EN" --context-text "$CONTEXT_EN" \
+            --source-label "$SOURCE_LABEL" --creator-handle "$CREATOR_HANDLE" \
+            > /tmp/props_en.json
+          echo "EN props:"; cat /tmp/props_en.json
+
+      - name: Build render props JSON (PT)
+        env:
+          STORY_ID: ${{ github.event.inputs.story_id }}
+          REVEAL_FRAME: ${{ github.event.inputs.reveal_frame }}
+          TOTAL_FRAMES: ${{ github.event.inputs.total_frames }}
+          HOOK_PT: ${{ github.event.inputs.hook_pt }}
+          CONTEXT_PT: ${{ github.event.inputs.context_text_pt }}
+          SOURCE_LABEL: ${{ github.event.inputs.source_label }}
+          CREATOR_HANDLE: ${{ github.event.inputs.creator_handle }}
+        run: |
+          python3 scripts/remotion/build_beforethecut_props.py \
+            --story-id "$STORY_ID" --language pt \
+            --reveal-frame "$REVEAL_FRAME" --total-frames "$TOTAL_FRAMES" \
+            --hook "$HOOK_PT" --context-text "$CONTEXT_PT" \
+            --source-label "$SOURCE_LABEL" --creator-handle "$CREATOR_HANDLE" \
+            > /tmp/props_pt.json
+          echo "PT props:"; cat /tmp/props_pt.json
+
+      # Gage devops change #1 — --concurrency=2 caps parallel decoders. EN then PT (sequential).
+      - name: Render EN reel
+        working-directory: scripts/remotion
+        run: |
+          npx remotion render src/Root.tsx BeforeTheCutEN \
+            --props /tmp/props_en.json \
+            --concurrency=2 \
+            --output /tmp/reel_en.mp4
+          echo "EN reel size: $(du -sh /tmp/reel_en.mp4)"
+
+      - name: Render PT reel
+        working-directory: scripts/remotion
+        run: |
+          npx remotion render src/Root.tsx BeforeTheCutPT \
+            --props /tmp/props_pt.json \
+            --concurrency=2 \
+            --output /tmp/reel_pt.mp4
+          echo "PT reel size: $(du -sh /tmp/reel_pt.mp4)"
+
+      # Gage devops change #3 — resolve Reels destination from routing.py (NOT SOVEREIGN_TEMPLATE_FOLDER).
+      - name: Resolve Reels destination folder
+        id: dest
+        env:
+          PROJECT: ${{ github.event.inputs.project }}
+        run: |
+          DEST=$(python3 -c "import sys; sys.path.insert(0,'scripts'); from routing import reels_folder; print(reels_folder('${PROJECT}'))")
+          echo "Reels folder for ${PROJECT}: $DEST"
+          [ -n "$DEST" ] || { echo "ERROR: no reels_folder_id for ${PROJECT} in routing.py"; exit 1; }
+          echo "folder_id=$DEST" >> $GITHUB_OUTPUT
+
+      - name: Upload reels to News Reels folder
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+          STORY_ID: ${{ github.event.inputs.story_id }}
+        run: |
+          python3 scripts/remotion/upload_reels.py \
+            --story-id "$STORY_ID" \
+            --topic-slug "beforethecut-$(echo '${{ github.event.inputs.story_id }}' | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9-')" \
+            --en-reel /tmp/reel_en.mp4 \
+            --pt-reel /tmp/reel_pt.mp4 \
+            --folder-id "${{ steps.dest.outputs.folder_id }}"
+
+      - name: Save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: beforethecut-reels-${{ github.run_id }}
+          path: |
+            /tmp/reel_en.mp4
+            /tmp/reel_pt.mp4
+          retention-days: 30
+
+      # Gage devops change #5 — failure logging from day one (global rule).
+      - name: Log pipeline failure + alert
+        if: failure()
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+          GMAIL_PASSWORD: ${{ secrets.PRI_OP_GMAIL_APP_PASSWORD }}
+          STORY_ID: ${{ github.event.inputs.story_id }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          python3 - << 'PYEOF'
+          import json, os, smtplib, urllib.parse, urllib.request
+          from datetime import datetime
+          from email.mime.text import MIMEText
+
+          story_id = os.environ.get("STORY_ID", "")
+          run_id = os.environ.get("GITHUB_RUN_ID", "")
+          run_url = f"https://github.com/priihigashi/oak-park-ai-hub/actions/runs/{run_id}"
+          stage = "render-beforethecut.yml"
+          err = f"FORMAT-025 render failed for {story_id} — see run log"
+
+          # 1) Append to 🚨 Pipeline Failures (Ideas & Inbox)
+          try:
+              td = json.loads(os.environ["SHEETS_TOKEN"])
+              data = urllib.parse.urlencode({
+                  "client_id": td["client_id"], "client_secret": td["client_secret"],
+                  "refresh_token": td["refresh_token"], "grant_type": "refresh_token",
+              }).encode()
+              token = json.loads(urllib.request.urlopen(urllib.request.Request(
+                  "https://oauth2.googleapis.com/token", data=data)).read())["access_token"]
+              SHEET_ID = "1IrFrCNGVIF7cvAr9cIuAXvCtUR_-eQN1mdCpHXpfbcU"
+              row = [[datetime.utcnow().isoformat() + "Z", "render-beforethecut.yml", run_id,
+                      stage, err, run_url, "", "FORMAT-025 MVP"]]
+              enc = urllib.parse.quote("'🚨 Pipeline Failures'!A:H", safe="!:'")
+              url = (f"https://sheets.googleapis.com/v4/spreadsheets/{SHEET_ID}/values/"
+                     f"{enc}:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS")
+              urllib.request.urlopen(urllib.request.Request(
+                  url, data=json.dumps({"values": row}).encode(),
+                  headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"}))
+              print("  Logged to Pipeline Failures tab")
+          except Exception as e:
+              print(f"  Pipeline failure log skipped: {e}")
+
+          # 2) SMTP alert
+          pw = os.environ.get("GMAIL_PASSWORD", "")
+          if pw:
+              try:
+                  msg = MIMEText(f"FORMAT-025 (Before The Cut) render failed.\n\nStory: {story_id}\nRun: {run_url}")
+                  msg["Subject"] = "❌ FORMAT-025 render failed"
+                  msg["From"] = "priscila@oakpark-construction.com"
+                  msg["To"] = "priscila@oakpark-construction.com"
+                  with smtplib.SMTP_SSL("smtp.gmail.com", 465, timeout=30) as s:
+                      s.login("priscila@oakpark-construction.com", pw)
+                      s.send_message(msg)
+                  print("  Alert email sent")
+              except Exception as e:
+                  print(f"  Alert email skipped: {e}")
+          PYEOF
+          # Re-raise non-zero so the ❌ shows and the run is marked failed
+          exit 1

--- a/scripts/remotion/build_beforethecut_props.py
+++ b/scripts/remotion/build_beforethecut_props.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+build_beforethecut_props.py — Generate Remotion render props JSON for FORMAT-025
+"Before The Cut" (deceptive-edit debunk reel). Outputs JSON to stdout (captured by
+render-beforethecut.yml).
+
+MANUAL MVP: the original-clip sourcing/alignment is supplied by hand (workflow inputs).
+The AUTO original_source_finder is a separate Phase-2 module — NOT built yet.
+
+Mirrors build_render_props.py patterns (SRT parse, PT translation via Haiku) but for
+the dual-video BeforeTheCut composition.
+
+Usage:
+  python build_beforethecut_props.py \\
+    --story-id NWS-2026... --language pt \\
+    --original-start-frame 0 --reveal-frame 150 --total-frames 900 \\
+    --hook "Cortaram o começo deste vídeo." \\
+    --context-text "Ele falava sobre X quando..." \\
+    --source-label "Fonte: TV Câmara — 14:32" \\
+    --creator-handle someaccount \\
+    [--srt-file /tmp/original_captions.srt] [--translate]
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+FPS = 30
+
+# Local file names the workflow drops into scripts/remotion/public/ before render.
+MANIPULATED_SRC = "./public/manipulated.mp4"
+ORIGINAL_SRC = "./public/original.mp4"
+
+
+def srt_time_to_frames(ts: str) -> int:
+    """Convert SRT timestamp HH:MM:SS,mmm to frame number at 30fps."""
+    hms, ms = ts.split(",")
+    h, m, s = hms.split(":")
+    total_sec = int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000
+    return round(total_sec * FPS)
+
+
+def parse_srt(srt_path: str) -> list:
+    """Parse an SRT into phase-2-local CaptionEntry list.
+
+    Captions describe the ORIGINAL clip. The original plays from frame 0 of the
+    downloaded window in phase 2, so SRT frames map directly to phase-2-local frames.
+    """
+    if not srt_path or not os.path.exists(srt_path):
+        return []
+    with open(srt_path, encoding="utf-8") as f:
+        content = f.read()
+    blocks = re.split(r"\n\n+", content.strip())
+    captions = []
+    for block in blocks:
+        lines = block.strip().split("\n")
+        if len(lines) < 3:
+            continue
+        match = re.match(
+            r"(\d{2}:\d{2}:\d{2},\d{3})\s+-->\s+(\d{2}:\d{2}:\d{2},\d{3})", lines[1]
+        )
+        if not match:
+            continue
+        captions.append({
+            "startFrame": srt_time_to_frames(match.group(1)),
+            "endFrame":   srt_time_to_frames(match.group(2)),
+            "text":       " ".join(lines[2:]).strip(),
+        })
+    return captions
+
+
+def translate_captions(captions: list, target_lang: str = "pt") -> list:
+    """Translate caption text to target language via Claude Haiku. Non-fatal if fails."""
+    api_key = os.environ.get("CLAUDE_KEY_4_CONTENT", "")
+    if not api_key or not captions:
+        return captions
+    try:
+        import urllib.request
+        texts = [c["text"] for c in captions]
+        prompt = (
+            "Translate these subtitle lines to Brazilian Portuguese. "
+            "Keep each line SHORT (subtitle length). Output ONLY a JSON array of strings, same order.\n\n"
+            + json.dumps(texts)
+        )
+        payload = json.dumps({
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 2000,
+            "messages": [{"role": "user", "content": prompt}],
+        }).encode()
+        req = urllib.request.Request(
+            "https://api.anthropic.com/v1/messages",
+            data=payload,
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+        )
+        resp = json.loads(urllib.request.urlopen(req, timeout=30).read())
+        translated = json.loads(resp["content"][0]["text"])
+        if len(translated) == len(captions):
+            return [{**c, "text": t} for c, t in zip(captions, translated)]
+    except Exception as e:
+        print(f"WARNING: caption translation failed: {e}", file=sys.stderr)
+    return captions
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--story-id", required=True)
+    parser.add_argument("--language", choices=["en", "pt"], default="pt")
+    parser.add_argument("--original-start-frame", type=int, default=0,
+                        help="Playback offset inside original.mp4. Default 0 — preroll is "
+                             "baked into the yt-dlp --download-sections window.")
+    parser.add_argument("--reveal-frame", type=int, default=150,
+                        help="Frame when the split appears (default 150 = 5s, after hook).")
+    parser.add_argument("--total-frames", type=int, default=900)
+    parser.add_argument("--hook", default="")
+    parser.add_argument("--context-text", default="",
+                        help="Plain-language 'what they were actually talking about'.")
+    parser.add_argument("--source-label", default="",
+                        help="e.g. 'Fonte: TV Câmara — 14:32'")
+    parser.add_argument("--creator-handle", default="",
+                        help="Handle that posted the manipulated cut (shown on phase-1 chip).")
+    parser.add_argument("--srt-file", default="",
+                        help="Optional SRT of the ORIGINAL clip (phase-2 captions).")
+    parser.add_argument("--translate", action="store_true",
+                        help="Translate captions to PT (use with --language pt).")
+    args = parser.parse_args()
+
+    captions = parse_srt(args.srt_file)
+    if args.translate and args.language == "pt":
+        captions = translate_captions(captions, "pt")
+
+    props = {
+        "manipulatedSrc":     MANIPULATED_SRC,
+        "originalSrc":        ORIGINAL_SRC,
+        "originalStartFrame": args.original_start_frame,
+        "revealFrame":        args.reveal_frame,
+        "totalFrames":        args.total_frames,
+        "hook":               args.hook,
+        "contextText":        args.context_text,
+        "captions":           captions,
+        "language":           args.language,
+        "creatorHandle":      args.creator_handle or None,
+        "sourceLabel":        args.source_label,
+    }
+    # strip None — Remotion ignores missing optional props cleanly
+    props = {k: v for k, v in props.items() if v is not None}
+    print(json.dumps(props, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/remotion/src/BeforeTheCut.tsx
+++ b/scripts/remotion/src/BeforeTheCut.tsx
@@ -4,7 +4,6 @@ import {
   OffthreadVideo,
   Sequence,
   useCurrentFrame,
-  useVideoConfig,
   interpolate,
 } from "remotion";
 

--- a/scripts/remotion/src/BeforeTheCut.tsx
+++ b/scripts/remotion/src/BeforeTheCut.tsx
@@ -1,0 +1,366 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  OffthreadVideo,
+  Sequence,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+} from "remotion";
+
+/**
+ * BeforeTheCut — FORMAT-025 "O Que Veio Antes / Before The Cut" reel.
+ *
+ * The deceptive-edit debunk: a viral clip was cut to flip its meaning.
+ * We expose it by playing the manipulated cut against the UNCUT original —
+ * including the seconds BEFORE the cut — so context is restored on screen.
+ *
+ * Three phases (driven by Sequence):
+ *   1. [0 .. revealFrame)        manipulated cut plays alone (audio ON) + hook overlay.
+ *   2. reveal card               brief "Agora o vídeo completo 👇" flash.
+ *   3. [revealFrame .. end)      SPLIT — top = manipulated (MUTED), bottom = original
+ *                                (audio ON — it IS the proof) + context band + captions.
+ *
+ * Why a separate composition from NewsReel:
+ *   NewsReel = one video + TEXT proof cards in the bottom zone.
+ *   BeforeTheCut = TWO videos stacked (cut vs uncut). Different mechanic, so a sibling
+ *   composition. Layout constants / colors mirror NewsReel deliberately (shared look),
+ *   re-declared locally to keep NewsReel.tsx 100% untouched (MVP — extract to _shared.tsx later).
+ *
+ * Render trigger: render-beforethecut.yml (BeforeTheCutEN + BeforeTheCutPT passes).
+ * Props built by: build_beforethecut_props.py.
+ */
+
+// ─── LAYOUT (mirrors NewsReel.tsx) ──────────────────────────────────────────────
+const W = 1080;
+const H = 1920;
+const HALF_Y = H / 2;          // 960px — equal top/bottom split for dual video
+const DIVIDER_H = 4;
+const PAD = 72;
+const HOOK_FRAMES = 150;        // 5s at 30fps
+const REVEAL_CARD_FRAMES = 24;  // ~0.8s flash at the reveal
+
+const C = {
+  obsidian: "#0E0D0B",
+  paper: "#F2ECE0",
+  accent: "#F4C430",   // canario gold — same as Rachadinha / NewsReel
+  blood: "#8B1A1A",
+  margin: "#6B6560",
+};
+
+export interface CaptionEntry {
+  startFrame: number;   // PHASE-2-LOCAL frames (aligned to the original playing from frame 0)
+  endFrame: number;
+  text: string;
+}
+
+export interface BeforeTheCutProps {
+  manipulatedSrc: string;       // local file in /public — the cut as posted
+  originalSrc: string;          // local file in /public — uncut window (already starts a few sec early)
+  originalStartFrame?: number;  // playback offset inside originalSrc (default 0 — preroll baked into the download)
+  revealFrame: number;          // when the split appears
+  totalFrames: number;
+  hook: string;
+  contextText: string;          // "what he was actually talking about"
+  captions: CaptionEntry[];
+  language: "en" | "pt";
+  creatorHandle?: string;       // who posted the manipulated cut
+  sourceLabel: string;          // "Fonte: TV Câmara — 14:32"
+}
+
+// ─── HOOK INTRO (phase 1 overlay) ───────────────────────────────────────────────
+const HookIntro: React.FC<{ hook: string; frame: number }> = ({ hook, frame }) => {
+  const opacity = interpolate(
+    frame,
+    [0, 8, HOOK_FRAMES - 12, HOOK_FRAMES],
+    [0, 1, 1, 0],
+    { extrapolateLeft: "clamp", extrapolateRight: "clamp" }
+  );
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: W,
+        height: H,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(11,11,12,0.62)",
+        opacity,
+        padding: `0 ${PAD}px`,
+        zIndex: 10,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "Fraunces, serif",
+          fontWeight: 700,
+          fontSize: 104,
+          color: C.paper,
+          lineHeight: 1.05,
+          textAlign: "center",
+          textShadow: "0 4px 24px rgba(0,0,0,0.95)",
+        }}
+      >
+        {hook}
+      </div>
+    </div>
+  );
+};
+
+// ─── REVEAL CARD (between phase 1 and phase 2) ──────────────────────────────────
+const RevealCard: React.FC<{ language: "en" | "pt"; localFrame: number }> = ({
+  language,
+  localFrame,
+}) => {
+  const opacity = interpolate(
+    localFrame,
+    [0, 6, REVEAL_CARD_FRAMES - 6, REVEAL_CARD_FRAMES],
+    [0, 1, 1, 0],
+    { extrapolateLeft: "clamp", extrapolateRight: "clamp" }
+  );
+  const text = language === "pt" ? "Agora o vídeo completo 👇" : "Now watch the full video 👇";
+  return (
+    <AbsoluteFill
+      style={{
+        background: C.obsidian,
+        opacity,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 20,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "Fraunces, serif",
+          fontWeight: 700,
+          fontSize: 88,
+          color: C.accent,
+          textAlign: "center",
+          padding: `0 ${PAD}px`,
+          lineHeight: 1.1,
+        }}
+      >
+        {text}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ─── CAPTION (burned-in, over original zone in phase 2) ─────────────────────────
+const Caption: React.FC<{ captions: CaptionEntry[]; localFrame: number }> = ({
+  captions,
+  localFrame,
+}) => {
+  const active = captions.find((c) => localFrame >= c.startFrame && localFrame < c.endFrame);
+  if (!active) return null;
+  return (
+    <div
+      style={{
+        position: "absolute",
+        bottom: 120,
+        left: PAD,
+        right: PAD,
+        background: "rgba(0,0,0,0.6)",
+        padding: "12px 20px",
+        color: C.paper,
+        fontFamily: "Inter, sans-serif",
+        fontWeight: 500,
+        fontSize: 38,
+        lineHeight: 1.4,
+        textAlign: "center",
+        textShadow: "0 2px 8px rgba(0,0,0,0.9)",
+      }}
+    >
+      {active.text}
+    </div>
+  );
+};
+
+// ─── ZONE LABEL (small chip identifying each video) ─────────────────────────────
+const ZoneLabel: React.FC<{ text: string; top: number; tone: "cut" | "real" }> = ({
+  text,
+  top,
+  tone,
+}) => (
+  <div
+    style={{
+      position: "absolute",
+      top: top + 20,
+      left: PAD,
+      background: tone === "cut" ? C.blood : C.accent,
+      color: tone === "cut" ? C.paper : C.obsidian,
+      fontFamily: "'JetBrains Mono', monospace",
+      fontWeight: 700,
+      fontSize: 24,
+      letterSpacing: 1,
+      padding: "6px 14px",
+      borderRadius: 4,
+      zIndex: 15,
+    }}
+  >
+    {text}
+  </div>
+);
+
+// ─── MAIN COMPOSITION ───────────────────────────────────────────────────────────
+export const BeforeTheCut: React.FC<BeforeTheCutProps> = ({
+  manipulatedSrc,
+  originalSrc,
+  originalStartFrame = 0,
+  revealFrame,
+  totalFrames,
+  hook,
+  contextText,
+  captions,
+  language,
+  creatorHandle,
+  sourceLabel,
+}) => {
+  const frame = useCurrentFrame();
+
+  const cutLabel = language === "pt" ? "O CORTE" : "THE CUT";
+  const realLabel = language === "pt" ? "O ORIGINAL" : "THE ORIGINAL";
+  const splitStart = revealFrame + REVEAL_CARD_FRAMES;
+
+  return (
+    <AbsoluteFill style={{ background: C.obsidian }}>
+      {/* ── PHASE 1: manipulated cut alone, audio ON ── */}
+      <Sequence from={0} durationInFrames={revealFrame}>
+        <OffthreadVideo
+          src={manipulatedSrc}
+          style={{ width: "100%", height: "100%", objectFit: "cover" }}
+        />
+        {creatorHandle ? <ZoneLabel text={`@${creatorHandle}`} top={0} tone="cut" /> : null}
+        {hook ? <HookIntro hook={hook} frame={frame} /> : null}
+      </Sequence>
+
+      {/* ── REVEAL CARD ── */}
+      <Sequence from={revealFrame} durationInFrames={REVEAL_CARD_FRAMES}>
+        <RevealCardWrapper language={language} />
+      </Sequence>
+
+      {/* ── PHASE 2: split — top muted cut, bottom uncut original (audio ON) ── */}
+      <Sequence from={splitStart} durationInFrames={Math.max(1, totalFrames - splitStart)}>
+        <SplitPhase
+          manipulatedSrc={manipulatedSrc}
+          originalSrc={originalSrc}
+          originalStartFrame={originalStartFrame}
+          captions={captions}
+          contextText={contextText}
+          sourceLabel={sourceLabel}
+          cutLabel={cutLabel}
+          realLabel={realLabel}
+        />
+      </Sequence>
+    </AbsoluteFill>
+  );
+};
+
+// RevealCard needs its own local frame (relative to its Sequence) → small wrapper.
+const RevealCardWrapper: React.FC<{ language: "en" | "pt" }> = ({ language }) => {
+  const localFrame = useCurrentFrame();
+  return <RevealCard language={language} localFrame={localFrame} />;
+};
+
+// SplitPhase reads its own local frame (relative to the phase-2 Sequence) so
+// caption timings + original playback line up regardless of revealFrame.
+const SplitPhase: React.FC<{
+  manipulatedSrc: string;
+  originalSrc: string;
+  originalStartFrame: number;
+  captions: CaptionEntry[];
+  contextText: string;
+  sourceLabel: string;
+  cutLabel: string;
+  realLabel: string;
+}> = ({
+  manipulatedSrc,
+  originalSrc,
+  originalStartFrame,
+  captions,
+  contextText,
+  sourceLabel,
+  cutLabel,
+  realLabel,
+}) => {
+  const localFrame = useCurrentFrame();
+  return (
+    <AbsoluteFill style={{ background: C.obsidian }}>
+      {/* TOP — the manipulated cut, MUTED + slightly desaturated to read as "the lie" */}
+      <div
+        style={{ position: "absolute", top: 0, left: 0, width: W, height: HALF_Y, overflow: "hidden" }}
+      >
+        <OffthreadVideo
+          src={manipulatedSrc}
+          muted
+          style={{ width: "100%", height: "100%", objectFit: "cover", filter: "grayscale(0.4)" }}
+        />
+        <ZoneLabel text={cutLabel} top={0} tone="cut" />
+      </div>
+
+      {/* DIVIDER */}
+      <div
+        style={{ position: "absolute", top: HALF_Y - DIVIDER_H / 2, left: 0, width: W, height: DIVIDER_H, background: C.accent, zIndex: 12 }}
+      />
+
+      {/* BOTTOM — the uncut original, audio ON (the proof) */}
+      <div
+        style={{ position: "absolute", top: HALF_Y, left: 0, width: W, height: H - HALF_Y, overflow: "hidden" }}
+      >
+        <OffthreadVideo
+          src={originalSrc}
+          startFrom={originalStartFrame}
+          style={{ width: "100%", height: "100%", objectFit: "cover" }}
+        />
+        <ZoneLabel text={realLabel} top={HALF_Y} tone="real" />
+        <Caption captions={captions} localFrame={localFrame} />
+      </div>
+
+      {/* CONTEXT BAND — what they were actually talking about */}
+      {contextText ? (
+        <div
+          style={{
+            position: "absolute",
+            top: HALF_Y - 4,
+            left: 0,
+            width: W,
+            transform: "translateY(-100%)",
+            background: "rgba(14,13,11,0.82)",
+            color: C.paper,
+            fontFamily: "Inter, sans-serif",
+            fontWeight: 600,
+            fontSize: 32,
+            lineHeight: 1.3,
+            padding: `18px ${PAD}px`,
+            zIndex: 11,
+          }}
+        >
+          {contextText}
+        </div>
+      ) : null}
+
+      {/* SOURCE LABEL — bottom strip */}
+      {sourceLabel ? (
+        <div
+          style={{
+            position: "absolute",
+            bottom: 28,
+            left: PAD,
+            right: PAD,
+            textAlign: "center",
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: 24,
+            color: C.margin,
+            zIndex: 14,
+          }}
+        >
+          {sourceLabel}
+        </div>
+      ) : null}
+    </AbsoluteFill>
+  );
+};

--- a/scripts/remotion/src/Root.tsx
+++ b/scripts/remotion/src/Root.tsx
@@ -8,6 +8,7 @@ import {
   EvidenceCompilationProps,
   evidenceCompilationDefaultProps,
 } from "./EvidenceCompilation";
+import { BeforeTheCut, BeforeTheCutProps } from "./BeforeTheCut";
 
 // Default props for development previews — overridden by --props in CI render
 const defaultProps: NewsReelProps = {
@@ -37,6 +38,21 @@ const carouselDefaultProps: CarouselMotionProps = {
   clipSrc: undefined,
   hookText: undefined,
   accentColor: "#F4C430",
+};
+
+// FORMAT-025 BeforeTheCut default props — overridden by --props in CI render.
+// Defaults render against placeholder clips for local preview only.
+const beforeTheCutDefaultProps: BeforeTheCutProps = {
+  manipulatedSrc: "./public/manipulated.mp4",
+  originalSrc: "./public/original.mp4",
+  originalStartFrame: 0,
+  revealFrame: 150,
+  totalFrames: 900,
+  hook: "Cortaram o começo deste vídeo.",
+  contextText: "",
+  captions: [],
+  language: "pt",
+  sourceLabel: "",
 };
 
 const RemotionRoot: React.FC = () => {
@@ -89,6 +105,24 @@ const RemotionRoot: React.FC = () => {
         width={1080}
         height={1920}
         defaultProps={evidenceCompilationDefaultProps as EvidenceCompilationProps}
+      />
+      <Composition
+        id="BeforeTheCutEN"
+        component={BeforeTheCut}
+        durationInFrames={900}
+        fps={30}
+        width={1080}
+        height={1920}
+        defaultProps={{ ...beforeTheCutDefaultProps, language: "en", hook: "They cut the start of this video." }}
+      />
+      <Composition
+        id="BeforeTheCutPT"
+        component={BeforeTheCut}
+        durationInFrames={900}
+        fps={30}
+        width={1080}
+        height={1920}
+        defaultProps={{ ...beforeTheCutDefaultProps, language: "pt" }}
       />
     </>
   );

--- a/scripts/remotion/src/Root.tsx
+++ b/scripts/remotion/src/Root.tsx
@@ -114,6 +114,7 @@ const RemotionRoot: React.FC = () => {
         width={1080}
         height={1920}
         defaultProps={{ ...beforeTheCutDefaultProps, language: "en", hook: "They cut the start of this video." }}
+        calculateMetadata={({ props }) => ({ durationInFrames: props.totalFrames || 900 })}
       />
       <Composition
         id="BeforeTheCutPT"
@@ -123,6 +124,7 @@ const RemotionRoot: React.FC = () => {
         width={1080}
         height={1920}
         defaultProps={{ ...beforeTheCutDefaultProps, language: "pt" }}
+        calculateMetadata={({ props }) => ({ durationInFrames: props.totalFrames || 900 })}
       />
     </>
   );


### PR DESCRIPTION
## FORMAT-025 — "O Que Veio Antes / Before The Cut" — Phase 1 MANUAL MVP

Deceptive-edit debunk reel: the LIE is the EDIT, not the claim. A viral clip is cut to flip its meaning; we expose it by playing the manipulated cut against the **uncut original** (including the seconds *before* the cut). Proof = the original video itself.

**Scope:** build-steps 1 & 2 (manual MVP). **STOPPED before build-step 3** (auto original-clip finder) for Priscila's visual review. Manual sourcing only for now (you supply original URL + window).

### Files
- **NEW** `scripts/remotion/src/BeforeTheCut.tsx` — dual-video split composition (NewsReel.tsx untouched)
- **NEW** `scripts/remotion/build_beforethecut_props.py` — manual props builder (smoke-tested)
- **NEW** `.github/workflows/render-beforethecut.yml` — manual `workflow_dispatch` pipeline
- edit `scripts/remotion/src/Root.tsx` — register BeforeTheCutEN/PT + `calculateMetadata` (additive)

### Devops changes baked in (Gage audit)
1. `--concurrency=2` + 8GB swap step (dual-video OOM mitigation)
2. `yt-dlp --download-sections` — window only, never the full (hours-long) original
3. Upload dest resolved from `routing.reels_folder()` — NOT `SOVEREIGN_TEMPLATE_FOLDER`
4. Zero new secrets (all 10 confirmed present)
5. Failure logging from day one — `log_pipeline_failure` + `if: failure()` SMTP + non-zero exit

### ⚠️ DOUBLE-CHECK (verify before relying)
1. **No end-to-end render has run yet** — code built + smoke-tested + YAML-valid, but dual-video OOM mitigation is theoretical until the first real run.
2. **PR base = `feat/educational-explainer-pipeline`** (FORMAT-025 was built on top of it). Targeting `main` would drag in unrelated educational-explainer work. Re-target when that branch merges.
3. News/Brazil + USA Reels_Shorts folder IDs came from routing.py — not eyeball-verified in Drive.
4. `startFrom` on OffthreadVideo is deprecated in newer Remotion (`trimBefore`) — fine on the pinned version, swap on upgrade.
5. Pre-existing debt: old `render-video.yml` has NO failure logging (logged in Pipeline Fix tracker, separate fix).
6. Captions optional in MVP (no original-clip SRT auto-gen yet — part of build-step 3).

Spec: `_Master Plans & Docs/FORMAT-025_BUILD_SPEC.md` (BUILD LOG section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
