### PR TITLE
email-ops: route action items to Focus

### DIFF
--- a/email-ops/OPERATOR.md
+++ b/email-ops/OPERATOR.md
@@ -87,8 +87,10 @@ Read `protected-senders.yaml` for the current list. Summary:
 ## Task rules
 
 - One unresolved issue = **one task row**, regardless of how many emails reference it.
-- Tasks go to the **📥 Inbox tab** of Ideas & Inbox spreadsheet (`1IrFrCNGVIF7cvAr9cIuAXvCtUR_-eQN1mdCpHXpfbcU`).
+- Actionable work goes to **Focus → Pending** (`_Focus Partner — STATE`, `1AlvtSGIZUWE1pzld2A8LL5bK4g9nRR4a4jqsOcfnY4c`).
+- The **📥 Inbox** tab is reserved for content references, someday ideas and low-priority inspiration — never as a fallback task queue.
 - Calendar events: ONLY for real dates / appointments — never for reports, receipts, or promos.
+- If Focus cannot be written, keep the email visibly labeled and report the failure. Do not silently create an Inbox row or archive the email.
 - No tasks from: reports, receipts, confirmations, promos, duplicates.
 - Read every candidate thread IN FULL before logging a task. Summaries are not enough.
 
@@ -98,7 +100,7 @@ Read `protected-senders.yaml` for the current list. Summary:
 
 1. ⚡ **Action Items**: do items that take <5 min now; archive on completion.
 2. ↩️ **Needs Reply**: reply, move awaited-reply threads to ⏳ Waiting + archive.
-3. **Over-5-min work** → one Inbox-tab row, archive the email.
+3. **Over-5-min work** → one Focus Pending task; archive only after the task write is verified.
 4. **Weekly sweep**: ⏳ Waiting label — follow up or close.
 5. **Label + archive** leftovers → target 0–10.
 

--- a/email-ops/change-log.md
+++ b/email-ops/change-log.md
@@ -4,6 +4,8 @@
 
 ---
 
+- **2026-07-29** — Routing corrected: actionable email work now goes to Focus → Pending; Calendar is only a genuine date/appointment reminder; Ideas & Inbox is reserved for content references/someday ideas. A failed Focus write keeps the email visibly labeled and is reported—never silently rerouted to Inbox.
+
 - **2026-07-26** — Daily Advancer (automated): created `task-routing.yaml` (when to create tasks vs archive, dedup rules, routing to ⚡/↩️/⏳), `pipelines.yaml` (pipeline → email subject map for all 15 workflows; flags unconfirmed email outputs), `runbook.md` (8-procedure operational guide covering morning routine, filter additions, pipeline mapping, repeat failure handling, weekly sweep, escalation), and this `change-log.md`. All 4 files referenced in OPERATOR.md Architecture table but missing from repo. WP-3 scaffold now complete.
 
 - **2026-07-25** — Claude Code (manual session): created initial repo scaffold — OPERATOR.md, inbox-policy.yaml, filters.yaml, labels.yaml, protected-senders.yaml. Transcribed from EMAIL_OPS_MASTER_PLAN v5 (Drive `1lf0NJQlkFhHDZb5ldr0YVGKgBdFXj5L2T3MCo23dlds`). WP-3 kickoff.

--- a/email-ops/filters.yaml
+++ b/email-ops/filters.yaml
@@ -8,7 +8,7 @@
 # BEFORE applying any filter:
 #   1. Verify the exact from/subject match against a real thread in the inbox
 #   2. Confirm the label ID via mcp__Gmail__list_labels (IDs rotate)
-#   3. Do NOT apply filter #5 (Mac restart) until restart task is logged in Inbox tab
+#   3. Do NOT apply filter #5 (Mac restart) until restart task is logged in Focus Pending
 #   4. A wrong filter can hide real human mail — when unsure, run audit mode first
 #
 # Gmail filter syntax docs: https://support.google.com/mail/answer/7190
@@ -68,8 +68,8 @@ filters:
       skip_inbox: true
       label: "🚨 Automation Errors"
       mark_read: true
-    status: conditional  # ACTIVATE ONLY after restart task is logged in Inbox tab
-    caution: "DO NOT activate until the one-off Mac restart task is logged in the Inbox tab. A new failure = a new task, not an archive."
+    status: conditional  # ACTIVATE ONLY after restart task is logged in Focus Pending
+    caution: "DO NOT activate until the one-off Mac restart task is logged in Focus Pending. A new failure = a new task, not an archive."
 
   - id: 6
     name: "Calendar Optimized / Daily Advancer — from mcfollingproperties@"
@@ -129,7 +129,7 @@ filters:
       label: "🤖 Automation/Pending Approval"
       mark_read: true
     status: conditional
-    caution: "Archive only once the single project-level task is logged in the Inbox tab for the content backlog. Not before."
+    caution: "Archive only once the single project-level task is logged in Focus Pending for the content backlog. Not before."
 
 never_create_filters_for:
   - "Official Anthropic billing/access/security mail — always stays in inbox"

--- a/email-ops/inbox-policy.yaml
+++ b/email-ops/inbox-policy.yaml
@@ -38,15 +38,18 @@ morning_routine:
     - label: "↩️ Needs Reply"
       action: "Reply; move awaited-reply to ⏳ Waiting + archive"
     - over_5_min:
-        action: "One Inbox-tab row; archive the email"
+        action: "One Focus Pending task; archive only after the Focus write is verified"
     - weekly:
         action: "Sweep ⏳ Waiting — follow up or close"
     - final:
         action: "Label + archive leftovers → target 0-10"
 
 task_rules:
-  destination_sheet: "1IrFrCNGVIF7cvAr9cIuAXvCtUR_-eQN1mdCpHXpfbcU"
-  destination_tab: "📥 Inbox"
+  destination_sheet: "1AlvtSGIZUWE1pzld2A8LL5bK4g9nRR4a4jqsOcfnY4c"
+  destination_tab: "Pending"
+  destination_system: "Focus — primary work/task queue"
+  focus_write_failure: "Keep the email visibly labeled and report the failed Focus write; never silently create an Inbox task."
+  inbox_is_reserved_for: "content references, someday ideas and low-priority inspiration only"
   one_task_per_issue: true
   read_thread_in_full_before_logging: true
   no_tasks_from:
@@ -74,7 +77,7 @@ pre_approved_filters:
   - id: 5
     matches: {subject_contains: "Mac restart", is_repeat: true}
     action: {skip_inbox: true, label: "🚨 Automation Errors", mark_read: true}
-    condition: "activate ONLY after restart task is logged in Inbox tab"
+    condition: "activate ONLY after restart task is logged in Focus Pending"
   - id: 6
     matches:
       from: "mcfollingproperties@gmail.com"

--- a/email-ops/pipelines.yaml
+++ b/email-ops/pipelines.yaml
@@ -111,7 +111,7 @@ approval:
     subject_pattern: "Approval Reminder"
     inbox_filter: 10
     label: "🤖 Automation/Pending Approval"
-    note: "Archive only AFTER the project-level task is logged in the Inbox tab. Not before."
+    note: "Archive only AFTER the project-level task is logged in Focus Pending. Not before."
 
 # ─────────────────────────────────────────
 # OUTBOUND-ONLY (sends emails, does not receive)

--- a/email-ops/protected-senders.yaml
+++ b/email-ops/protected-senders.yaml
@@ -40,7 +40,7 @@ protected_categories:
   - Any thread that only Priscila can resolve (requires physical action or login)
 
 only_priscila_actions:
-  # These stay in inbox until done. Log one task row per issue; never archive prematurely.
+  # These stay in inbox until done. Log one Focus Pending task per issue; never archive prematurely.
   - item: "Anthropic API — DO NOT top up credits yet. First: review usage at console.anthropic.com/settings/usage, then disable 5 ACTIVE_RECOMMENDED_PAUSE workflows, add budget limits + global kill switch per pipeline-control/pipelines.yaml WP-0. Auto-reload stays OFF."
     ref: "pipeline-control/pipelines.yaml wp0_status.pending_only_you"
   - item: "Mac admin password (5AM restart failure)"

--- a/email-ops/runbook.md
+++ b/email-ops/runbook.md
@@ -12,7 +12,7 @@
 1. Run `audit` mode: count threads, categorize, flag uncertain ones.
 2. Process **⚡ Action Items** — do items that take <5 min now; archive on completion.
 3. Process **↩️ Needs Reply** — reply, then move to **⏳ Waiting** + archive.
-4. Any item that takes >5 min → log ONE task row in Ideas & Inbox 📥 Inbox tab, then archive the email.
+4. Any item that takes >5 min → log ONE task in Focus Pending, verify the write, then archive the email.
 5. Label + archive everything else per `filters.yaml` rules.
 6. Target: 0–10 threads remaining (hard cap: 30).
 
@@ -49,9 +49,9 @@
 
 **Only the FIRST occurrence creates a task. Repeats get archived.**
 
-1. Check the Ideas & Inbox 📥 Inbox tab — does an open task for this failure already exist?
+1. Check Focus Pending — does an open task for this failure already exist?
    - YES → Read the new email for any new information. Add a note if useful. Archive the email. Do not create a second task.
-   - NO → Create one task row. Apply label **⚡ Action Items**. Keep in inbox until resolved.
+   - NO → Create one Focus Pending task. Apply label **⚡ Action Items**. Keep the email visible until the Focus write is verified.
 2. If the failure is from a pipeline flagged `ACTIVE_RECOMMENDED_PAUSE` in `pipeline-control/pipelines.yaml` → add to the existing WP-0 follow-up task, do not open a new task.
 
 ---
@@ -60,7 +60,7 @@
 
 1. List all threads labeled **⏳ Waiting**.
 2. For each: check if the awaited action has happened.
-   - Resolved → archive and close the task in Ideas & Inbox.
+   - Resolved → archive and close the task in Focus.
    - Still waiting → leave as-is or nudge if overdue.
    - Dropped → archive + mark task Done with note "dropped / not actioned".
 
@@ -81,6 +81,7 @@
 
 If a thread doesn't clearly match any category:
 - Default to **keep in inbox** and flag for Priscila in the audit report.
+- If a Focus write fails, keep the email visibly labeled, report the failure and do not substitute an Inbox task.
 - State exactly: what the email is, why it's uncertain, and the two most likely actions.
 - Do NOT archive uncertain threads during `morning-zero` — only automation-noise threads are safe to auto-archive.
 
@@ -101,4 +102,4 @@ If a thread doesn't clearly match any category:
 | Change log | `email-ops/change-log.md` |
 | Master pipeline registry (LLM costs) | `pipeline-control/pipelines.yaml` |
 | Human-readable master plan | Drive doc `1lf0NJQlkFhHDZb5ldr0YVGKgBdFXj5L2T3MCo23dlds` |
-| Task destination sheet | Spreadsheet `1IrFrCNGVIF7cvAr9cIuAXvCtUR_-eQN1mdCpHXpfbcU`, tab 📥 Inbox |
+| Task destination sheet | Spreadsheet `1AlvtSGIZUWE1pzld2A8LL5bK4g9nRR4a4jqsOcfnY4c`, tab Pending |

--- a/email-ops/task-routing.yaml
+++ b/email-ops/task-routing.yaml
@@ -4,12 +4,15 @@
 # Source: EMAIL_OPS_MASTER_PLAN v5 + OPERATOR.md
 #
 # PURPOSE: Machine-readable rules for the inbox operator deciding what becomes a task.
-# RULE: One unresolved issue = ONE task row in Ideas & Inbox 📥 Inbox tab, regardless of email count.
+# RULE: One unresolved issue = ONE task row in Focus Pending, regardless of email count.
 # Read thread IN FULL before logging. Summaries are not enough.
 
 task_destination:
-  spreadsheet_id: "1IrFrCNGVIF7cvAr9cIuAXvCtUR_-eQN1mdCpHXpfbcU"
-  tab: "📥 Inbox"
+  spreadsheet_id: "1AlvtSGIZUWE1pzld2A8LL5bK4g9nRR4a4jqsOcfnY4c"
+  tab: "Pending"
+  system_of_record: "Focus Pending is the primary work queue."
+  access_failure:
+    action: "Do not create an Inbox task as a fallback. Keep the email visibly labeled and report that Focus write access failed."
   fields:
     date_added: "today (YYYY-MM-DD)"
     type: "✅ Task"
@@ -21,8 +24,14 @@ task_destination:
     status: "🆕 New"
     topic: "specific subject of the issue"
 
+content_reference_destination:
+  spreadsheet_id: "1IrFrCNGVIF7cvAr9cIuAXvCtUR_-eQN1mdCpHXpfbcU"
+  tab: "📥 Inbox"
+  use_only_for: "content references, someday ideas and low-priority inspiration that Priscila is not planning to work on soon"
+  never_use_for: "actionable work, replies, deadlines, active projects or email follow-ups"
+
 # ─────────────────────────────────────────
-# ALWAYS CREATE A TASK — inbox stays open
+# ALWAYS CREATE A TASK — keep the email visible until the Focus task is verified
 # ─────────────────────────────────────────
 always_task:
   - category: only_you_items
@@ -121,7 +130,7 @@ no_task:
 # TASK COUNT GUARD
 # ─────────────────────────────────────────
 task_count_guard:
-  rule: "Before logging any task, search the Inbox tab for the same issue. Only log if no open row exists."
+  rule: "Before logging any task, search Focus Pending for the same issue. Only log if no open row exists."
   dedup_key: "Issue title + niche + open status. Same words + same project = same task."
   max_new_tasks_per_audit_run: 10
   note: "If more than 10 new tasks surface in a single session, pause and flag to Priscila — it means the inbox has deep backlog, not routine noise."


### PR DESCRIPTION
## What changed
Actionable email work now routes to Focus → Pending. Calendar remains a reminder layer only when an email contains a real date or appointment. Ideas & Inbox is reserved for content references, someday ideas, and low-priority inspiration.

## Safety behavior
If Focus cannot be written, the email remains visibly labeled and the failure is reported. The operator must not silently create an Inbox task or archive the email.

## Why
Focus is Priscila’s primary work queue; the Inbox is currently a parked content/reference store, not an active task system.

## Validation
- Parsed every `email-ops/*.yaml` file successfully.
- Confirmed the active email-operations documents no longer direct actionable tasks to the old Inbox tab.
- Checked the patch for whitespace errors.