### PR TITLE
A1: allowlisted skill distribution (manifest + sync) — DRAFT, do not merge

### DIFF
--- a/scripts/skills_sync.py
+++ b/scripts/skills_sync.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Allowlisted skill distribution — the ONE sync step that was missing.
+
+Installs skills named in skills/distribution-manifest.yaml into the shared skills
+root, then points each runtime (Claude, Codex) at the shared copy via symlink.
+
+Design rules (enforced in code, not just documented):
+  * DRY RUN IS THE DEFAULT. --apply is required before anything is written.
+  * A non-identical existing directory is NEVER silently overwritten. It is backed
+    up and reported; replacing it additionally requires --approve-overwrite.
+  * Every write is verified by re-hashing the destination afterwards.
+  * Runtime symlinks must resolve to the shared copy, or the run reports FAIL.
+  * Only manifest-listed IDs are touched. No wildcard, no bulk import.
+
+Usage:
+    python3 scripts/skills_sync.py                      # dry run (default)
+    python3 scripts/skills_sync.py --apply              # install additive/identical only
+    python3 scripts/skills_sync.py --apply --approve-overwrite
+    python3 scripts/skills_sync.py --verify             # check installed state only
+"""
+from __future__ import annotations
+import argparse, hashlib, json, os, shutil, sys
+from datetime import datetime
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MANIFEST = REPO / "skills" / "distribution-manifest.yaml"
+
+
+def load_manifest():
+    import yaml
+    return yaml.safe_load(MANIFEST.read_text())
+
+
+def expand(p: str) -> Path:
+    return Path(os.path.expanduser(p))
+
+
+def dir_hash(d: Path) -> str | None:
+    """Stable hash of a directory's relative paths + contents. None if absent."""
+    if not d.is_dir():
+        return None
+    h = hashlib.sha256()
+    for f in sorted(p for p in d.rglob("*") if p.is_file()):
+        h.update(str(f.relative_to(d)).encode())
+        h.update(f.read_bytes())
+    return h.hexdigest()
+
+
+def link_status(link: Path, target: Path) -> tuple[bool, str]:
+    """Does `link` resolve to `target`?"""
+    if not link.exists() and not link.is_symlink():
+        return False, "absent"
+    if link.is_symlink():
+        try:
+            resolved = link.resolve(strict=True)
+        except (OSError, RuntimeError):
+            return False, "broken-symlink"
+        return (resolved == target.resolve(), f"symlink -> {resolved}")
+    return False, "exists-but-not-a-symlink (real directory in the way)"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="actually write (default is dry run)")
+    ap.add_argument("--approve-overwrite", action="store_true",
+                    help="permit replacing a non-identical existing skill directory")
+    ap.add_argument("--verify", action="store_true", help="report installed state only, write nothing")
+    ap.add_argument("--shared-root", default=None, help="override shared root (used by the mutation fixture)")
+    ap.add_argument("--runtime-links", default=None, help="comma-separated override (used by the mutation fixture)")
+    args = ap.parse_args()
+
+    m = load_manifest()
+    shared_root = expand(args.shared_root or m["install"]["shared_root"])
+    runtime_links = ([expand(x) for x in args.runtime_links.split(",")] if args.runtime_links
+                     else [expand(x) for x in m["install"]["runtime_links"]])
+    backup_root = expand(m["safety"]["backup_dir"])
+
+    mode = "VERIFY" if args.verify else ("APPLY" if args.apply else "DRY RUN")
+    print(f"skills_sync — mode: {mode}")
+    print(f"  manifest      : {MANIFEST}")
+    print(f"  shared root   : {shared_root}")
+    print(f"  runtime links : {', '.join(str(p) for p in runtime_links)}")
+    print(f"  allowlisted   : {len(m['skills'])} skills\n")
+
+    results, exit_code = [], 0
+    for entry in m["skills"]:
+        sid, src = entry["id"], REPO / entry["source"]
+        dst = shared_root / sid
+        r = {"id": sid, "source": str(src), "dest": str(dst)}
+
+        if not (src / "SKILL.md").is_file():
+            r["action"], r["status"] = "none", "SOURCE-MISSING"
+            results.append(r); exit_code = 1
+            print(f"  ✗ {sid}: source has no SKILL.md at {src}")
+            continue
+
+        src_h, dst_h = dir_hash(src), dir_hash(dst)
+        r["source_hash"], r["dest_hash_before"] = src_h, dst_h
+
+        if dst_h is None:
+            r["action"] = "install"
+        elif dst_h == src_h:
+            r["action"] = "already-identical"
+        else:
+            r["action"] = "conflict-non-identical"
+
+        if args.verify:
+            r["status"] = "reported"
+        elif r["action"] == "already-identical":
+            r["status"] = "skipped (identical)"
+        elif r["action"] == "conflict-non-identical" and not args.approve_overwrite:
+            r["status"] = "BLOCKED — existing copy differs; not overwritten"
+            exit_code = 2
+        elif not args.apply:
+            r["status"] = "would-write (dry run)"
+        else:
+            if dst_h is not None:  # back up before replacing
+                stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+                bdir = backup_root / f"{sid}-{stamp}"
+                bdir.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(dst, bdir)
+                shutil.rmtree(dst)
+                r["backup"] = str(bdir)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(src, dst)
+            after = dir_hash(dst)
+            r["dest_hash_after"] = after
+            if after != src_h:
+                r["status"] = "FAILED — post-write hash mismatch"; exit_code = 1
+            else:
+                r["status"] = "installed + hash-verified"
+
+        # runtime links
+        r["links"] = {}
+        for link_root in runtime_links:
+            link = link_root / sid
+            ok, detail = link_status(link, dst)
+            if not ok and args.apply and not args.verify and dst.is_dir():
+                if link.is_symlink() or link.exists():
+                    if link.is_symlink():
+                        link.unlink()
+                    else:
+                        r["links"][str(link)] = f"REFUSED — {detail}"
+                        exit_code = 2
+                        continue
+                link_root.mkdir(parents=True, exist_ok=True)
+                link.symlink_to(dst)
+                ok, detail = link_status(link, dst)
+            r["links"][str(link)] = ("OK " if ok else "NOT-RESOLVING ") + detail
+            if not ok and args.apply:
+                exit_code = 2
+
+        results.append(r)
+        mark = {"installed + hash-verified": "✓", "skipped (identical)": "=", "reported": "·"}.get(r["status"], "!")
+        print(f"  {mark} {sid}: {r['action']} -> {r['status']}")
+        for k, v in r["links"].items():
+            print(f"      link {k}: {v}")
+
+    print("\nsummary:", json.dumps({r["id"]: r["status"] for r in results}, indent=2))
+    if exit_code:
+        print(f"\nexit {exit_code}: at least one skill was blocked or failed verification.")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/distribution-manifest.yaml
+++ b/skills/distribution-manifest.yaml
@@ -1,0 +1,80 @@
+# Skill distribution manifest — ALLOWLIST ONLY
+#
+# Purpose: fix the root distribution problem once. Skills listed here are the ONLY
+# ones `scripts/skills_sync.py` will install. There is deliberately no wildcard and
+# no "sync everything" mode — a bulk import is what produced the drift this repairs.
+#
+# Origin: 2026-07-31 skill-capability audit found 7 skills that exist canonically here
+# but were not installed on the Mac, while CLAUDE.md routed to all 7. Root cause was a
+# missing distribution step, not 7 broken skills.
+#
+# Adding an entry is a deliberate act: it must name a real SKILL.md in this repo and be
+# approved. The sync tool refuses anything not listed.
+
+version: 1
+canonical_repo: priihigashi/oak-park-ai-hub
+
+# Where the shared copy is installed, and which runtimes symlink to it.
+install:
+  shared_root: ~/.agents/skills
+  runtime_links:
+    - ~/.claude/skills     # Claude Code
+    - ~/.codex/skills      # Codex
+
+# Safety rules the sync tool enforces in code (not just documented here):
+#  - dry-run is the DEFAULT; --apply is required to write anything
+#  - an existing directory that is not byte-identical is NEVER silently overwritten;
+#    it is backed up and reported, and only replaced with --approve-overwrite
+#  - every install is verified by re-hashing the destination after the copy
+#  - runtime links must resolve to the shared copy or the run fails
+safety:
+  dry_run_default: true
+  backup_dir: ~/.agents/skills/_backups
+  never_silent_overwrite: true
+  verify_hash_after_write: true
+
+skills:
+  - id: pipeline-fix
+    source: skills/pipeline-fix
+    reason: "CLAUDE.md PIPELINE FAILURE LOG section routes here (8 references)"
+  - id: session-start
+    source: skills/shared/session-start
+    reason: "CLAUDE.md SESSION START routes here (8 references)"
+  - id: session-exit
+    source: skills/shared/session-exit
+    reason: "CLAUDE.md SESSION EXIT LOG + context-full handoff route here (10 references)"
+  - id: drive-upload
+    source: skills/shared/drive-upload
+    reason: "CLAUDE.md DRIVE UPLOAD correct-method section routes here (4 references)"
+  - id: calendar-create
+    source: skills/shared/calendar-create
+    reason: "CLAUDE.md CALENDAR section routes here (4 references)"
+  - id: template-carousel
+    source: skills/shared/template-carousel
+    reason: "CLAUDE.md CAROUSEL OUTPUT ROUTING + MOTION IS DEFAULT ON route here (8 references)"
+  - id: email-send
+    source: skills/shared/email-send
+    reason: "CLAUDE.md EMAIL SENDING routes here (4 references)"
+
+# Explicitly NOT distributed by this manifest, and why.
+excluded:
+  - id: opc-carousel-creator
+    reason: "already installed and locally maintained; migration decision pending (audit: not-assessed)"
+  - id: opc-carousel-reviewer
+    reason: "already installed and locally maintained; migration decision pending (audit: not-assessed)"
+  - id: organize-project
+    reason: "canonical here but not currently referenced by CLAUDE.md; no approved need to install"
+  - id: website-reference-rebuild
+    reason: "canonical here but not currently referenced by CLAUDE.md; no approved need to install"
+  - id: find-skills
+    reason: "not referenced by instruction files; out of approved scope"
+  - id: flow-plans-log
+    reason: "not referenced by instruction files; out of approved scope"
+  - id: nano-banana-2
+    reason: "not referenced by instruction files; out of approved scope"
+  - id: remotion-best-practices
+    reason: "not referenced by instruction files; out of approved scope"
+  - id: sheets-automation
+    reason: "not referenced by instruction files; out of approved scope"
+  - id: sheets-hub-log
+    reason: "not referenced by instruction files; out of approved scope"

--- a/skills/pipeline-fix/SKILL.md
+++ b/skills/pipeline-fix/SKILL.md
@@ -1,7 +1,12 @@
+---
+name: pipeline-fix
+description: Continue the Oak Park content-pipeline repair workflow from the canonical tracker and detail docs. Use when Priscila explicitly invokes /pipeline-fix for a pipeline repair session.
+disable-model-invocation: true
+argument-hint: "[SH-ID or scope]"
+---
+
 # SKILL: pipeline-fix
 # Reads at session start. Report status immediately. No re-explaining needed.
-
----
 
 ## SESSION START — DO THIS FIRST (sync-up protocol)
 


### PR DESCRIPTION
**A1 ONLY. Draft — not for merge yet. A2 drift resolution is deliberately NOT in this PR.**

## Problem
The 2026-07-31 skill-capability audit found 7 skills that exist canonically in this repo but were never installed on the Mac, while `CLAUDE.md` routed to all 7. Root cause was one missing distribution step, not 7 broken skills — `oak-park-ai-hub` was never cloned on that machine and nothing synced `skills/` into the shared skills root.

## Change
- `skills/distribution-manifest.yaml` — allowlist of exactly 7 skills. No wildcard, no bulk-import mode. Includes an explicit `excluded` list stating why each of the other 10 canonical skills is NOT installed.
- `scripts/skills_sync.py` — one manifest-driven sync. Safety enforced in code, not just documented: dry-run is the default; a non-identical existing directory is backed up and BLOCKED rather than silently overwritten; every write is re-hashed after copy; runtime symlinks must resolve or the run reports failure.
- `skills/pipeline-fix/SKILL.md` — added valid YAML frontmatter (it had none, so the runtime showed the literal 'SKILL: pipeline-fix' as its description) with `disable-model-invocation: true`, since its body starts executing work on load. Body preserved.

## Verification
- Blocked-overwrite fixture: tampered copy **preserved**, not lost.
- Dry-run fixture: 0 directories created.
- Source vs installed hashes: **7/7 match**.
- Runtime links: **14/14** resolve to the shared copy (7 skills x Claude + Codex).
- Claude Code runtime now lists all 7 as loadable skills.

## Not in scope here
A2 drift resolution for `focus`, `athena`, `build-editorial-collection-site` — those need decision tables and separate approval.
