### PR TITLE
Add read-only Ads monthly cap monitor

### DIFF
--- a/.github/workflows/ads_monthly_cap_monitor.yml
+++ b/.github/workflows/ads_monthly_cap_monitor.yml
@@ -1,0 +1,62 @@
+name: OPC Ads Monthly Cap Monitor (Read Only)
+
+on:
+  workflow_dispatch:
+    inputs:
+      warning_dollars:
+        description: "Review threshold; no automatic pause"
+        required: false
+        default: "1450"
+      cap_dollars:
+        description: "Monthly cap target"
+        required: false
+        default: "1500"
+      customer_id:
+        description: "Oak Park Ads customer ID without dashes"
+        required: false
+        default: "8945889168"
+
+permissions:
+  contents: read
+
+jobs:
+  monthly-cap-monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run read-only monthly cap monitor
+        env:
+          GOOGLE_ADS_DEVELOPER_TOKEN: ${{ secrets.GOOGLE_ADS_DEVELOPER_TOKEN }}
+          GOOGLE_ADS_MCC_ID: ${{ secrets.GOOGLE_ADS_MCC_ID }}
+          GOOGLE_ADS_CUSTOMER_ID: ${{ inputs.customer_id }}
+          PRI_OP_ADS_TOKEN: ${{ secrets.PRI_OP_ADS_TOKEN }}
+          ADS_WARNING_DOLLARS: ${{ inputs.warning_dollars }}
+          ADS_CAP_DOLLARS: ${{ inputs.cap_dollars }}
+        run: python scripts/ads_monthly_cap_monitor.py
+
+      - name: Add status to workflow summary
+        if: always()
+        run: |
+          STATUS_FILE="artifacts/ads-monthly-cap-monitor/monthly_cap_status.md"
+          if [ -f "$STATUS_FILE" ]; then
+            cat "$STATUS_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No monthly cap status was generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload status artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: opc-ads-monthly-cap-status
+          path: artifacts/ads-monthly-cap-monitor/
+          if-no-files-found: warn

--- a/scripts/ads_monthly_cap_monitor.py
+++ b/scripts/ads_monthly_cap_monitor.py
@@ -1,0 +1,165 @@
+"""Read-only month-to-date Google Ads spend monitor for Oak Park Construction.
+
+This monitor intentionally has no campaign mutation path. It reports when the
+account crosses a warning threshold or monthly cap so a separately approved
+control can act on verified data.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ads_report import ads_search, load_config, micros_to_dollars
+
+
+DEFAULT_WARNING_DOLLARS = 1450.0
+DEFAULT_CAP_DOLLARS = 1500.0
+OUTPUT_DIR = Path(
+    os.environ.get("ADS_CAP_OUTPUT_DIR", "artifacts/ads-monthly-cap-monitor")
+)
+
+
+@dataclass(frozen=True)
+class CapDecision:
+    state: str
+    spend_dollars: float
+    warning_dollars: float
+    cap_dollars: float
+    remaining_to_cap_dollars: float
+    action: str
+
+
+def parse_dollars(name: str, default: float) -> float:
+    raw = os.environ.get(name, str(default)).strip()
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be a number, got: {raw!r}") from exc
+    if value <= 0:
+        raise RuntimeError(f"{name} must be greater than zero")
+    return value
+
+
+def decide_cap_state(
+    spend_dollars: float,
+    warning_dollars: float = DEFAULT_WARNING_DOLLARS,
+    cap_dollars: float = DEFAULT_CAP_DOLLARS,
+) -> CapDecision:
+    if spend_dollars < 0:
+        raise ValueError("spend_dollars cannot be negative")
+    if warning_dollars <= 0 or cap_dollars <= 0:
+        raise ValueError("warning and cap must be greater than zero")
+    if warning_dollars >= cap_dollars:
+        raise ValueError("warning must be lower than cap")
+
+    if spend_dollars >= cap_dollars:
+        state = "CAP_EXCEEDED"
+        action = (
+            "Do not assume delivery has stopped. Verify the live account now and "
+            "request explicit approval for any campaign pause."
+        )
+    elif spend_dollars >= warning_dollars:
+        state = "PAUSE_REVIEW_REQUIRED"
+        action = (
+            "Verify the live account now. A campaign pause still requires the "
+            "separately approved control path."
+        )
+    else:
+        state = "BELOW_WARNING"
+        action = "No control action requested; continue monitoring."
+
+    return CapDecision(
+        state=state,
+        spend_dollars=round(spend_dollars, 2),
+        warning_dollars=round(warning_dollars, 2),
+        cap_dollars=round(cap_dollars, 2),
+        remaining_to_cap_dollars=round(max(cap_dollars - spend_dollars, 0.0), 2),
+        action=action,
+    )
+
+
+def account_spend(raw_rows: list[dict[str, Any]]) -> float:
+    if not raw_rows:
+        raise RuntimeError("Google Ads returned no month-to-date customer metrics")
+    return sum(
+        micros_to_dollars((row.get("metrics") or {}).get("costMicros"))
+        for row in raw_rows
+    )
+
+
+def build_markdown(payload: dict[str, Any]) -> str:
+    decision = payload["decision"]
+    return "\n".join(
+        [
+            "# OPC Google Ads Monthly Cap Monitor",
+            "",
+            f"- Generated: {payload['generated_at']}",
+            f"- Customer: {payload['customer_id']}",
+            f"- Month-to-date spend: ${decision['spend_dollars']:,.2f}",
+            f"- Warning threshold: ${decision['warning_dollars']:,.2f}",
+            f"- Monthly cap target: ${decision['cap_dollars']:,.2f}",
+            f"- State: **{decision['state']}**",
+            f"- Remaining to cap: ${decision['remaining_to_cap_dollars']:,.2f}",
+            "",
+            "## Next action",
+            "",
+            decision["action"],
+            "",
+            "## Safety and accuracy",
+            "",
+            "- Read-only: this monitor never pauses or changes a campaign.",
+            "- Google Ads cost reporting and workflow execution can lag, so this is "
+            "a warning system—not a guaranteed billing hard stop.",
+            "- A native Google Ads billing limit, if available, remains the preferred route.",
+            "- Any automated pause needs separate approval, failure alerts, and a tested resume path.",
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    warning_dollars = parse_dollars("ADS_WARNING_DOLLARS", DEFAULT_WARNING_DOLLARS)
+    cap_dollars = parse_dollars("ADS_CAP_DOLLARS", DEFAULT_CAP_DOLLARS)
+    config = load_config()
+
+    query = """
+        SELECT
+          customer.id,
+          metrics.cost_micros
+        FROM customer
+        WHERE segments.date DURING THIS_MONTH
+    """
+    spend_dollars = account_spend(ads_search(config, query))
+    decision = decide_cap_state(spend_dollars, warning_dollars, cap_dollars)
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "customer_id": config.customer_id,
+        "date_range": "THIS_MONTH",
+        "decision": asdict(decision),
+        "mutation_performed": False,
+    }
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    json_path = OUTPUT_DIR / "monthly_cap_status.json"
+    markdown_path = OUTPUT_DIR / "monthly_cap_status.md"
+    json_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    markdown_path.write_text(build_markdown(payload), encoding="utf-8")
+
+    print(build_markdown(payload))
+    print(f"Wrote JSON: {json_path}")
+    print(f"Wrote Markdown: {markdown_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/tests/test_ads_monthly_cap_monitor.py
+++ b/scripts/tests/test_ads_monthly_cap_monitor.py
@@ -1,0 +1,43 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ads_monthly_cap_monitor import account_spend, decide_cap_state
+
+
+class CapDecisionTests(unittest.TestCase):
+    def test_below_warning(self):
+        decision = decide_cap_state(1200)
+        self.assertEqual(decision.state, "BELOW_WARNING")
+        self.assertEqual(decision.remaining_to_cap_dollars, 300)
+
+    def test_warning_boundary(self):
+        decision = decide_cap_state(1450)
+        self.assertEqual(decision.state, "PAUSE_REVIEW_REQUIRED")
+
+    def test_cap_boundary(self):
+        decision = decide_cap_state(1500)
+        self.assertEqual(decision.state, "CAP_EXCEEDED")
+        self.assertEqual(decision.remaining_to_cap_dollars, 0)
+
+    def test_invalid_threshold_order_fails_closed(self):
+        with self.assertRaises(ValueError):
+            decide_cap_state(100, warning_dollars=1500, cap_dollars=1500)
+
+    def test_empty_api_result_fails_closed(self):
+        with self.assertRaises(RuntimeError):
+            account_spend([])
+
+    def test_multiple_rows_are_summed(self):
+        rows = [
+            {"metrics": {"costMicros": "1250000000"}},
+            {"metrics": {"costMicros": "125000000"}},
+        ]
+        self.assertEqual(account_spend(rows), 1375)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- adds a manual, read-only month-to-date Google Ads spend monitor
- reports `BELOW_WARNING`, `PAUSE_REVIEW_REQUIRED`, or `CAP_EXCEEDED`
- defaults to a $1,450 review threshold and $1,500 monthly cap target
- publishes a Markdown summary and JSON evidence artifact
- adds boundary and fail-closed tests

## Why

The August $1,500 cap task needs a safe fallback if a native Billing monthly spend limit is unavailable. This change creates the evidence and warning layer without pretending API reporting is an exact billing hard stop.

## Safety

- manual trigger only; no schedule
- contents read permission only
- no Google Ads mutation endpoint or campaign-pause code
- any automated pause remains a separate approval and implementation step

## Validation

- `python3 -m unittest scripts.tests.test_ads_monthly_cap_monitor` — 6 tests pass
- Python compilation passes with an isolated bytecode cache
- workflow YAML parses successfully
- `git diff --check` passes
- existing live read-only Ads report for August returned $0.00 month-to-date spend; campaigns were paused or removed
