### PR TITLE
ci(content_creator): lock Remotion install with npm ci --include=dev

### DIFF
--- a/.github/workflows/content_creator.yml
+++ b/.github/workflows/content_creator.yml
@@ -226,7 +226,7 @@ jobs:
           pip install google-auth google-api-python-client pytz requests yt-dlp curl_cffi pytubefix pillow anthropic openai google-generativeai
           npm install playwright
           npx playwright install chromium --with-deps
-          cd scripts/remotion && npm install
+          cd scripts/remotion && npm ci --include=dev
 
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
@@ -444,7 +444,7 @@ jobs:
           pip install google-auth google-api-python-client pytz requests yt-dlp curl_cffi pytubefix pillow anthropic openai google-generativeai
           npm install playwright
           npx playwright install chromium --with-deps
-          cd scripts/remotion && npm install
+          cd scripts/remotion && npm ci --include=dev
 
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg


### PR DESCRIPTION
Follow-up to #231, which committed `scripts/remotion/package-lock.json` and moved
`render-video.yml`, `clipmine_render.yml` and `quality-js.yml` to a deterministic
locked Remotion install.

`content_creator.yml` was left behind and had **two** Remotion install sites
(lines 229 and 447), both still using mutable `npm install`. This changes both to:

```
cd scripts/remotion && npm ci --include=dev
```

`--include=dev` is required: these jobs use Playwright, which lives in the Remotion
package's `devDependencies`.

**Ordering note:** this deliberately could not land before #231 — `npm ci` hard-fails
without a committed lockfile, and the lockfile only reached `main` via #231.

Scope is surgical — only the two install commands changed. The `setup-node` action
version, the Node 24 pin, and the rest of the dependency block are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)