### PR TITLE
ci(quality-js): drop path filters ahead of required-check enforcement

### DIFF
--- a/.github/workflows/quality-js.yml
+++ b/.github/workflows/quality-js.yml
@@ -1,24 +1,17 @@
 name: JS/TS Quality Gate
 
+# NO `paths:` FILTER — deliberate, do not re-add.
+# These two jobs are REQUIRED status checks on `main`. A required check that is
+# skipped by a path filter never reports a conclusion, so GitHub leaves it
+# "Expected — waiting for status" and the PR can never merge. A docs-only PR
+# would be blocked forever. Both jobs finish in ~20s, so running them on every
+# PR is far cheaper than the deadlock.
+# See: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs
 on:
   pull_request:
-    paths:
-      - 'scripts/**'
-      - 'eslint.config.mjs'
-      - 'eslint-suppressions.json'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/quality-js.yml'
   push:
     branches:
       - main
-    paths:
-      - 'scripts/**'
-      - 'eslint.config.mjs'
-      - 'eslint-suppressions.json'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/quality-js.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Prerequisite for branch protection. `main` is currently `protected: false` with
zero rulesets and zero required status checks — so the quality gate reports red
but nothing stops a merge or a direct push. This is step 1 of making it a real gate.

Removes the `paths:` filters from `quality-js.yml`.

**Why this must happen first:** a required status check that gets skipped by a
path filter never reports a conclusion. GitHub leaves it as *"Expected — waiting
for status"* and the PR can never merge. Turning on required checks while the
path filter is in place would deadlock the next docs-only PR permanently.

Both jobs run in ~20s, so unconditional execution is far cheaper than the
deadlock. An inline comment explains why, so it doesn't get re-added.

Next: create a ruleset requiring `ESLint complexity` + `Remotion typecheck`,
and block direct pushes to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)