### PR TITLE
ci: add branch ruleset config to make the quality gate binding

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,70 @@
+# Branch rulesets
+
+## `main-require-quality-gate.json`
+
+Turns the JS/TS Quality Gate from *"CI that reports red"* into an actual gate.
+
+As of 2026-08-11 `main` is `protected: false` with zero rulesets and zero required
+status checks — so a PR can be merged while `ESLint complexity` or `Remotion typecheck`
+is failing, and `main` can be pushed to directly. This ruleset closes that.
+
+### Apply it
+
+```bash
+gh api -X POST repos/priihigashi/oak-park-ai-hub/rulesets \
+  --input .github/rulesets/main-require-quality-gate.json
+```
+
+Verify:
+
+```bash
+gh api repos/priihigashi/oak-park-ai-hub/rulesets --jq '.[] | "\(.id) \(.name) \(.enforcement)"'
+```
+
+To update an existing ruleset instead of creating a duplicate, use its id:
+
+```bash
+gh api -X PUT repos/priihigashi/oak-park-ai-hub/rulesets/<ID> \
+  --input .github/rulesets/main-require-quality-gate.json
+```
+
+To roll back:
+
+```bash
+gh api -X DELETE repos/priihigashi/oak-park-ai-hub/rulesets/<ID>
+```
+
+### What it does
+
+| Rule | Effect |
+|---|---|
+| `required_status_checks` | `ESLint complexity` and `Remotion typecheck` must pass before merge |
+| `deletion` | `main` cannot be deleted |
+| `non_fast_forward` | no force-pushing `main` |
+
+### The bypass is deliberate — do not remove it
+
+`actor_id: 15368` is the **GitHub Actions** integration. Three workflows commit
+directly to `main` using `secrets.GITHUB_TOKEN`, and all three break without this:
+
+- `nonnegotiables.yml` — the nightly 4AM `nonnegotiables-bot` update
+- `ads_pulse.yml` — refreshes `docs/dashboard/*.html`
+- `ads_approval_watcher.yml` — writes `.github/agent_state/ads_api_approved.json`
+
+Repository admins are **not** given a bypass, on purpose. Multiple agent sessions
+act with an admin token; an admin bypass would make the gate toothless for exactly
+the actor it exists to constrain. If you are genuinely stuck, set `enforcement` to
+`"evaluate"` or `"disabled"` and re-apply, rather than adding an admin bypass.
+
+### Why the path filters had to go first
+
+`quality-js.yml` previously had `paths:` filters. A required status check that is
+skipped by a path filter never reports a conclusion — GitHub shows it as
+*"Expected — waiting for status"* and the PR can never merge. PR #235 removed the
+filters for this reason. **Do not re-add them while these checks are required.**
+
+### Check the context names still match
+
+The `context` values must equal the job `name:` fields in `quality-js.yml`
+(`ESLint complexity`, `Remotion typecheck`). Renaming a job without updating this
+file leaves a required check that never reports — the same deadlock.

--- a/.github/rulesets/main-require-quality-gate.json
+++ b/.github/rulesets/main-require-quality-gate.json
@@ -1,0 +1,33 @@
+{
+  "name": "main: require quality gate",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 15368,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "ESLint complexity" },
+          { "context": "Remotion typecheck" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Final piece of Phase 1 enforcement. Verified against the live repo today:

```
main: protected = false
required_status_checks = []
rulesets = 0
```

So the quality gate reports red but **cannot stop anything** — a PR merges with
failing checks, and `main` accepts direct pushes. This commits the ruleset as
version-controlled config so it is reviewable and reversible.

### Contents

- `.github/rulesets/main-require-quality-gate.json` — the ruleset
- `.github/rulesets/README.md` — apply / verify / update / rollback commands, and why each choice was made

### Validated, not assumed

Required contexts are checked to exactly match the job `name:` values in
`quality-js.yml` (`ESLint complexity`, `Remotion typecheck`). A mismatch would
leave a required check that never reports and deadlock every PR.

### Bypass: GitHub Actions only, deliberately

Three workflows push to `main` with `secrets.GITHUB_TOKEN` and break without the
integration bypass — `nonnegotiables.yml` (the nightly 4AM bot), `ads_pulse.yml`,
`ads_approval_watcher.yml`.

Repository admins get **no** bypass on purpose: multiple agent sessions act with
an admin token, so an admin bypass would exempt exactly the actor this constrains.

### Prerequisite already landed

PR #235 removed the `paths:` filters from `quality-js.yml`. A required check that
is path-skipped never reports a conclusion and blocks the PR forever — so that
had to come first.

### Not applied

Creating the ruleset is a repo-settings API call this session was not permitted
to make. Merging this PR does **not** activate it; run the command in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)