### PR TITLE
TEST: prove the gate blocks a failing merge (throwaway)

### DIFF
--- a/scripts/__gate_falsifiability_probe.js
+++ b/scripts/__gate_falsifiability_probe.js
@@ -1,0 +1,7 @@
+// THROWAWAY — proves the required check actually blocks a merge. Delete after.
+export function deliberatelyTooComplex(a,b,c,d,e,f,g,h,i,j,k,l) {
+  if (a) return 1; if (b) return 2; if (c) return 3; if (d) return 4;
+  if (e) return 5; if (f) return 6; if (g) return 7; if (h) return 8;
+  if (i) return 9; if (j) return 10; if (k) return 11; if (l) return 12;
+  return 0;
+}


### PR DESCRIPTION
Throwaway PR. Contains one deliberately over-threshold function so `ESLint complexity` fails. Expected: GitHub REFUSES the merge, not merely displays red. Deleted immediately after.