### PR TITLE
ci: let bots pass through the quality gate instead of bypassing it

### DIFF
--- a/.github/workflows/ads_approval_watcher.yml
+++ b/.github/workflows/ads_approval_watcher.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write             # needed to commit the flag file
+  actions: write              # required to dispatch quality-js.yml (see scripts/ci/push_prevalidated_main.sh)
 
 jobs:
   watch:
@@ -21,6 +22,8 @@ jobs:
       calendar_link: ${{ steps.check.outputs.calendar_link }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history: push_prevalidated_main.sh may rebase onto a moved main
 
       - name: Install dependencies
         run: pip install --quiet google-auth google-auth-httplib2 google-api-python-client
@@ -34,12 +37,21 @@ jobs:
 
       - name: Commit flag file if approval detected
         if: steps.check.outputs.approved == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           git config user.name  "ads-approval-watcher"
           git config user.email "bot@oak-park-ai-hub.local"
           git add .github/agent_state/ads_api_approved.json
-          git commit -m "Ads API Basic Access approved — flag written" || echo "Nothing to commit"
-          git push
+          if git diff --staged --quiet; then
+            echo "Flag file unchanged — nothing to commit."
+            exit 0
+          fi
+          git commit -m "Ads API Basic Access approved — flag written"
+          # main is protected by ruleset 20720805 with no bypass actors, so a
+          # direct `git push` is rejected. Land through the gate instead.
+          bash scripts/ci/push_prevalidated_main.sh ads-approval
 
   notify:
     needs: watch

--- a/.github/workflows/ads_pulse.yml
+++ b/.github/workflows/ads_pulse.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write   # required to dispatch quality-js.yml (see scripts/ci/push_prevalidated_main.sh)
 
 jobs:
   refresh:
@@ -15,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0   # full history: push_prevalidated_main.sh may rebase onto a moved main
 
       - uses: actions/setup-python@v5
         with:
@@ -35,12 +37,21 @@ jobs:
         run: python scripts/ads_dashboard.py
 
       - name: Commit updated dashboard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/dashboard/index.html docs/dashboard/dark.html
-          git diff --staged --quiet || git commit -m "chore: refresh ads dashboard $(date -u +%Y-%m-%d)"
-          git push
+          if git diff --staged --quiet; then
+            echo "Dashboard unchanged — nothing to commit."
+            exit 0
+          fi
+          git commit -m "chore: refresh ads dashboard $(date -u +%Y-%m-%d)"
+          # main is protected by ruleset 20720805 with no bypass actors, so a
+          # direct `git push` is rejected. Land through the gate instead.
+          bash scripts/ci/push_prevalidated_main.sh ads-pulse
 
       - name: Email alert on failure
         if: failure()

--- a/.github/workflows/nonnegotiables.yml
+++ b/.github/workflows/nonnegotiables.yml
@@ -2,21 +2,30 @@ name: Nonnegotiables Updater
 
 on:
   schedule:
-    # 2:00 AM ET daily (before inventory at 3 AM, before 4AM agent at 4 AM)
-    - cron: '0 7 * * *'
+    # 2:00 AM ET daily (before inventory at 3 AM, before 4AM agent at 4 AM).
+    # `timezone:` makes this DST-safe. The previous `cron: '0 7 * * *'` had no
+    # timezone, so it ran at 07:00 UTC = 03:00 EDT in summer — an hour later than
+    # the comment claimed, and it would have drifted to 02:00 only in winter.
+    - cron: '0 2 * * *'
+      timezone: America/New_York
   workflow_dispatch:
 
 jobs:
   update:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Raised from 10: the updater now waits on a quality-gate run before it can
+    # land on main (see scripts/ci/push_prevalidated_main.sh). The gate itself
+    # takes ~25s, but queueing can add minutes.
+    timeout-minutes: 25
     permissions:
       contents: write
+      actions: write        # required to dispatch quality-js.yml on the bot branch
 
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0   # full history: push_prevalidated_main.sh may rebase onto a moved main
 
       - uses: actions/setup-python@v5
         with:
@@ -38,6 +47,9 @@ jobs:
           GIT_AUTHOR_EMAIL: actions@github.com
           GIT_COMMITTER_NAME: nonnegotiables-bot
           GIT_COMMITTER_EMAIL: actions@github.com
+          # push_prevalidated_main.sh shells out to `gh` to dispatch the quality
+          # gate and read its check runs — without GH_TOKEN it cannot authenticate.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/nonnegotiables_updater.py
 
       - name: Alert on failure

--- a/.github/workflows/quality-js.yml
+++ b/.github/workflows/quality-js.yml
@@ -7,11 +7,21 @@ name: JS/TS Quality Gate
 # would be blocked forever. Both jobs finish in ~20s, so running them on every
 # PR is far cheaper than the deadlock.
 # See: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs
+#
+# workflow_dispatch is REQUIRED, not optional convenience. Automated writers
+# (nonnegotiables, ads_pulse, ads_approval_watcher) cannot push directly to main
+# under ruleset 20720805 — required checks apply to pushes and there is no bypass.
+# They instead push to a temporary bot/* branch and dispatch this workflow against
+# it, so the commit carries passing checks before it reaches main. A push made with
+# GITHUB_TOKEN does not trigger a workflow, but workflow_dispatch does — which is
+# why this trigger is the mechanism, and removing it breaks all three bots.
+# See scripts/ci/push_prevalidated_main.sh
 on:
   pull_request:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/scripts/ci/push_prevalidated_main.sh
+++ b/scripts/ci/push_prevalidated_main.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# push_prevalidated_main.sh — land an automated commit on a ruleset-protected main
+# WITHOUT granting any bypass actor.
+#
+# WHY THIS EXISTS
+# ---------------
+# Ruleset 20720805 requires "ESLint complexity" and "Remotion typecheck" on main,
+# with bypass_actors: []. Ruleset required-status-checks apply to DIRECT PUSHES,
+# not just merges — a bot pushing straight to main is rejected with
+# "2 of 2 required status checks are expected".
+#
+# GitHub does accept a push whose commit ALREADY has the required checks passing.
+# So instead of bypassing the gate, bots pass through it:
+#
+#   commit locally
+#     -> push that exact commit to a temporary bot/* branch
+#     -> workflow_dispatch quality-js.yml against that branch
+#     -> wait for the run, then verify the check runs on the EXACT SHA
+#     -> push the same green SHA to main
+#     -> delete the temporary branch
+#
+# workflow_dispatch is required: a push made with GITHUB_TOKEN deliberately does
+# NOT trigger another workflow, but workflow_dispatch invoked with GITHUB_TOKEN
+# does create a run.
+#
+# USAGE
+#   scripts/ci/push_prevalidated_main.sh <label>
+#
+#   Call it with the commit ALREADY created on the local checkout of main.
+#   <label> is a short slug used in the temp branch name (e.g. "nonnegotiables").
+#
+# REQUIREMENTS in the calling workflow
+#   permissions:
+#     contents: write
+#     actions:  write        # <- required to dispatch quality-js.yml
+#   env:
+#     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+# EXIT CODES
+#   0  commit is on main (or there was nothing to push)
+#   1  validation failed, timed out, or the push was rejected — CALLER MUST FAIL
+#
+set -euo pipefail
+
+LABEL="${1:?usage: push_prevalidated_main.sh <label>}"
+REPO="${GITHUB_REPOSITORY:-priihigashi/oak-park-ai-hub}"
+RUN_ID="${GITHUB_RUN_ID:-manual$$}"
+GATE_WORKFLOW="quality-js.yml"
+REQUIRED_CHECKS=("ESLint complexity" "Remotion typecheck")
+POLL_SECONDS="${POLL_SECONDS:-15}"
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-900}"   # 15 min; the gate normally runs in ~25s
+MAX_REBASE_ATTEMPTS=2
+
+BOT_BRANCH="bot/${LABEL}-${RUN_ID}"
+
+log()  { printf '[prevalidated-push] %s\n' "$*"; }
+fail() { printf '[prevalidated-push] ERROR: %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  # Best-effort delete of the temp ref. Never mask the real exit code.
+  git push origin --delete "$BOT_BRANCH" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# --- 0. Is there anything to do? --------------------------------------------
+git fetch origin main --quiet
+LOCAL_SHA="$(git rev-parse HEAD)"
+REMOTE_SHA="$(git rev-parse origin/main)"
+
+if [ "$LOCAL_SHA" = "$REMOTE_SHA" ]; then
+  log "HEAD already matches origin/main — nothing to push."
+  exit 0
+fi
+
+if ! git merge-base --is-ancestor "$REMOTE_SHA" "$LOCAL_SHA"; then
+  fail "HEAD is not a descendant of origin/main. Rebase before calling this."
+fi
+
+# --- validate one SHA through the gate --------------------------------------
+validate_sha() {
+  local sha="$1"
+
+  log "pushing $sha to $BOT_BRANCH for validation"
+  git push --force origin "${sha}:refs/heads/${BOT_BRANCH}" \
+    || fail "could not push temporary branch $BOT_BRANCH"
+
+  log "dispatching $GATE_WORKFLOW against $BOT_BRANCH"
+  gh workflow run "$GATE_WORKFLOW" --repo "$REPO" --ref "$BOT_BRANCH" \
+    || fail "could not dispatch $GATE_WORKFLOW (is 'actions: write' set?)"
+
+  local waited=0
+  local conclusion=""
+  while [ "$waited" -lt "$MAX_WAIT_SECONDS" ]; do
+    sleep "$POLL_SECONDS"
+    waited=$(( waited + POLL_SECONDS ))
+
+    # Only consider runs whose head_sha is EXACTLY the commit we are landing.
+    # Results from any other SHA are worthless here.
+    conclusion="$(gh run list --repo "$REPO" --workflow "$GATE_WORKFLOW" \
+        --branch "$BOT_BRANCH" --limit 10 \
+        --json headSha,status,conclusion \
+        --jq "[.[] | select(.headSha==\"$sha\" and .status==\"completed\")][0].conclusion // \"\"")"
+
+    [ -n "$conclusion" ] && break
+    log "  waiting for gate run on $sha (${waited}s)"
+  done
+
+  [ -n "$conclusion" ] || fail "gate did not complete within ${MAX_WAIT_SECONDS}s for $sha"
+  [ "$conclusion" = "success" ] || fail "gate concluded '$conclusion' for $sha — refusing to push"
+
+  # Belt and braces: assert each REQUIRED check individually, by name, on this SHA.
+  # A green workflow run is not the same claim as "every required context passed".
+  local checks
+  checks="$(gh api "repos/${REPO}/commits/${sha}/check-runs" --paginate \
+      --jq '.check_runs[] | "\(.name)=\(.conclusion)"')"
+
+  local c
+  for c in "${REQUIRED_CHECKS[@]}"; do
+    if ! grep -Fxq "${c}=success" <<<"$checks"; then
+      log "check runs present on $sha:"
+      printf '  %s\n' $checks
+      fail "required check '$c' is not success on $sha"
+    fi
+    log "  verified: $c = success on $sha"
+  done
+}
+
+# --- 1..N. validate, then push; rebase and revalidate if main moved ----------
+attempt=1
+while [ "$attempt" -le "$MAX_REBASE_ATTEMPTS" ]; do
+  SHA="$(git rev-parse HEAD)"
+  validate_sha "$SHA"
+
+  log "pushing validated $SHA to main (attempt $attempt)"
+  if git push origin "HEAD:main"; then
+    log "SUCCESS — $SHA is on main, validated by the same gate humans face."
+    exit 0
+  fi
+
+  log "push rejected — main likely moved. Rebasing and revalidating the NEW sha."
+  log "(check results do not carry across SHAs, so this must re-run the gate.)"
+  git fetch origin main --quiet
+  git rebase origin/main || fail "rebase onto origin/main failed — manual intervention needed"
+  attempt=$(( attempt + 1 ))
+done
+
+fail "could not land commit on main after ${MAX_REBASE_ATTEMPTS} attempts"

--- a/scripts/nonnegotiables_updater.py
+++ b/scripts/nonnegotiables_updater.py
@@ -186,14 +186,40 @@ def _update_datestamp():
 
 
 def _git_commit(count):
-    try:
-        subprocess.run(["git", "add", "NONNEGOTIABLES.md"], cwd=REPO_ROOT, check=True)
-        msg = f"chore: nonnegotiables_updater — {count} new candidate(s) extracted {datetime.now(ET).strftime('%Y-%m-%d')}"
-        subprocess.run(["git", "commit", "-m", msg], cwd=REPO_ROOT, check=True)
-        subprocess.run(["git", "push", "origin", "main"], cwd=REPO_ROOT, check=True)
-        print(f"  Committed + pushed NONNEGOTIABLES.md ({count} new rules)")
-    except subprocess.CalledProcessError as e:
-        print(f"  Git commit skipped or failed: {e}")
+    """Commit NONNEGOTIABLES.md and land it on main through the quality gate.
+
+    Raises on failure — DO NOT swallow. Until 2026-08-11 this caught
+    CalledProcessError, printed "Git commit skipped or failed" and returned
+    normally, so a rejected push produced a GREEN workflow with NONNEGOTIABLES.md
+    silently not updated. That false all-clear became reachable the moment
+    ruleset 20720805 started rejecting direct pushes to main.
+    """
+    subprocess.run(["git", "add", "NONNEGOTIABLES.md"], cwd=REPO_ROOT, check=True)
+
+    msg = (
+        f"chore: nonnegotiables_updater — {count} new candidate(s) extracted "
+        f"{datetime.now(ET).strftime('%Y-%m-%d')}"
+    )
+    commit = subprocess.run(
+        ["git", "commit", "-m", msg], cwd=REPO_ROOT,
+        capture_output=True, text=True,
+    )
+    if commit.returncode != 0:
+        # "nothing to commit" is the one benign non-zero exit here.
+        combined = (commit.stdout or "") + (commit.stderr or "")
+        if "nothing to commit" in combined:
+            print("  Nothing to commit — NONNEGOTIABLES.md unchanged.")
+            return
+        raise subprocess.CalledProcessError(
+            commit.returncode, commit.args, commit.stdout, commit.stderr
+        )
+
+    # main is protected by ruleset 20720805 with no bypass actors, so a direct
+    # push is rejected. Route through the gate instead: temp branch -> dispatch
+    # quality-js.yml -> verify the checks on this exact SHA -> push the same SHA.
+    helper = REPO_ROOT / "scripts" / "ci" / "push_prevalidated_main.sh"
+    subprocess.run(["bash", str(helper), "nonnegotiables"], cwd=REPO_ROOT, check=True)
+    print(f"  Committed + pushed NONNEGOTIABLES.md ({count} new rules)")
 
 
 def main():


### PR DESCRIPTION
Solves the regression from applying ruleset `20720805` **without** weakening the gate.

### The problem

Ruleset required-status-checks apply to **direct pushes**, not just merges.
Verified: a push to `main` was rejected with *"2 of 2 required status checks are
expected"* even as repository admin. All three automated writers push straight to
`main`, so all three would have begun failing — `nonnegotiables.yml` first.

The obvious fix, a `RepositoryRole=write` bypass, is the wrong trade here: it
exempts every human writer too, in a repo where agent sessions hold write/admin
tokens. `Integration` bypass is unavailable (422 — org-owned repos only).

### The fix — bots go through the gate, not around it

`scripts/ci/push_prevalidated_main.sh`:

```
commit locally
  -> push exact SHA to bot/<label>-<run_id>
  -> workflow_dispatch quality-js.yml --ref that branch
  -> wait for the run whose head_sha == that exact SHA
  -> assert EACH required check name is success on that SHA
  -> push the same SHA to main
  -> delete temp branch
```

GitHub accepts the final push because the commit already carries passing checks.
If `main` moved while waiting, it rebases and **revalidates** — check results
never carry across SHAs. Never force-pushes `main`.

`quality-js.yml` gains `workflow_dispatch`. That is the mechanism, not a
convenience: a push made with `GITHUB_TOKEN` does not trigger a workflow, but
`workflow_dispatch` invoked with `GITHUB_TOKEN` does. Removing that trigger
breaks all three bots — there's a comment saying so.

### Two pre-existing bugs found while tracing this

**1. False all-clear.** `nonnegotiables_updater._git_commit()` caught
`CalledProcessError`, printed *"Git commit skipped or failed"*, and returned
normally. A rejected push would have produced a **green** workflow with
`NONNEGOTIABLES.md` silently not updated. It now raises; `"nothing to commit"`
remains the one benign case. `ads_approval_watcher.yml` had the same shape via
`|| echo "Nothing to commit"` — both now distinguish no-op from failure.

**2. Wrong schedule.** `cron: '0 7 * * *'` has no timezone, so it fired at
**03:00 EDT**, not the 02:00 ET its comment claimed. Now `'0 2 * * *'` with
`timezone: America/New_York`, which is DST-safe.

### Also

`fetch-depth: 0` on all three checkouts so the rebase path has history.
`actions: write` added where dispatch is needed. `nonnegotiables` timeout
10 → 25 min for gate queueing.

**Verification plan after merge:** manually dispatch `nonnegotiables.yml` and
confirm a green SHA reaches `main` through the temp-branch route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)