### PR TITLE
ci: bots need pull-requests:write — the prevalidated-SHA design does not work

### DIFF
--- a/.github/workflows/ads_approval_watcher.yml
+++ b/.github/workflows/ads_approval_watcher.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   contents: write             # needed to commit the flag file
-  actions: write              # required to dispatch quality-js.yml (see scripts/ci/push_prevalidated_main.sh)
+  pull-requests: write   # helper opens+merges a PR (see scripts/ci/push_prevalidated_main.sh)
 
 jobs:
   watch:

--- a/.github/workflows/ads_pulse.yml
+++ b/.github/workflows/ads_pulse.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  actions: write   # required to dispatch quality-js.yml (see scripts/ci/push_prevalidated_main.sh)
+  pull-requests: write   # helper opens+merges a PR (see scripts/ci/push_prevalidated_main.sh)
 
 jobs:
   refresh:

--- a/.github/workflows/nonnegotiables.yml
+++ b/.github/workflows/nonnegotiables.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: write
-      actions: write        # required to dispatch quality-js.yml on the bot branch
+      pull-requests: write   # helper opens+merges a PR (see scripts/ci/push_prevalidated_main.sh)
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality-js.yml
+++ b/.github/workflows/quality-js.yml
@@ -8,13 +8,17 @@ name: JS/TS Quality Gate
 # PR is far cheaper than the deadlock.
 # See: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs
 #
-# workflow_dispatch is REQUIRED, not optional convenience. Automated writers
-# (nonnegotiables, ads_pulse, ads_approval_watcher) cannot push directly to main
-# under ruleset 20720805 — required checks apply to pushes and there is no bypass.
-# They instead push to a temporary bot/* branch and dispatch this workflow against
-# it, so the commit carries passing checks before it reaches main. A push made with
-# GITHUB_TOKEN does not trigger a workflow, but workflow_dispatch does — which is
-# why this trigger is the mechanism, and removing it breaks all three bots.
+# Automated writers (nonnegotiables, ads_pulse, ads_approval_watcher) cannot push
+# directly to main under ruleset 20720805 — required checks apply to pushes and
+# there is no bypass actor. They open a PR instead, so the `pull_request` trigger
+# below is what gates them, exactly as it gates a human.
+#
+# workflow_dispatch is kept for manual re-runs. It is NOT the bot mechanism: an
+# earlier design dispatched this workflow against a temp branch and then pushed
+# the pre-validated SHA to main. That was tested and REJECTED by GitHub — both
+# required checks reported success on the exact SHA and the push was still
+# refused with "2 of 2 required status checks are expected". Ruleset push
+# evaluation does not honour pre-existing check runs. Do not retry that design.
 # See scripts/ci/push_prevalidated_main.sh
 on:
   pull_request:


### PR DESCRIPTION
Follow-up to #239 after testing that design end to end and finding it wrong.

### The negative result

The "push the exact SHA to a temp ref, get it green, then push the same SHA to
main" model — which GitHub's *branch protection* troubleshooting docs describe —
**does not work under a ruleset.** Tested for real:

```
[prevalidated-push]   verified: ESLint complexity = success on 0f6a4b60...
[prevalidated-push]   verified: Remotion typecheck = success on 0f6a4b60...
[prevalidated-push] pushing validated 0f6a4b60... to main
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
```

Both required check runs reported `success` on that exact SHA (confirmed via
`/commits/{sha}/check-runs`) and the push was still refused. Ruleset push
evaluation does not honour pre-existing check runs.

### What works instead — proven

The helper now opens a PR and merges it. Verified end to end:
bot branch → **PR #240** → both checks green on the head SHA → merged → `main`,
temp branch auto-deleted, zero `bot/*` branches left behind.

The `pull_request` trigger gates the bot exactly as it gates a human, and
`bypass_actors` stays `[]`.

### This PR

- `pull-requests: write` replaces `actions: write` on all three bot workflows
- `quality-js.yml` keeps `workflow_dispatch` for manual re-runs, but its comment
  now records the failed design so nobody rebuilds it

🤖 Generated with [Claude Code](https://claude.com/claude-code)