### PR TITLE
Fix Content Creator V2 stable identities

### DIFF
--- a/scripts/content_creator_v2/ffprobe.py
+++ b/scripts/content_creator_v2/ffprobe.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
-import uuid
 from pathlib import Path
 from typing import Optional
 
 from .contracts import MediaAsset
+from .stable_ids import asset_id as stable_asset_id
 
 
 def _sha256(path: Path, chunk: int = 1 << 20) -> str:
@@ -103,7 +103,9 @@ def extract(
     checksum = _sha256(path)
 
     return MediaAsset(
-        asset_id=asset_id or str(uuid.uuid4()),
+        # A path is the folder indexer's source identity. Photos and other
+        # adapters should pass their own durable source ID explicitly.
+        asset_id=asset_id or stable_asset_id(f"file:{path}"),
         path=str(path),
         source=source,
         owner=owner,

--- a/scripts/content_creator_v2/scene_extractor.py
+++ b/scripts/content_creator_v2/scene_extractor.py
@@ -13,11 +13,12 @@ import re
 import shutil
 import subprocess
 import tempfile
-import uuid
 from pathlib import Path
 from typing import Optional
 
 from .contracts import MediaAsset, Scene
+from .stable_ids import asset_id as stable_asset_id
+from .stable_ids import keyframe_name, scene_id
 
 
 _SCENE_THRESHOLD = 0.30   # FFmpeg scene-change score (0.0–1.0); raise to merge short cuts
@@ -67,20 +68,29 @@ def detect_scenes(
     return pairs or [(0.0, round(duration, 3))]
 
 
-def extract_keyframe(video_path: str, timestamp: float, output_dir: Path) -> str:
+def extract_keyframe(
+    video_path: str,
+    timestamp: float,
+    output_dir: Path,
+    *,
+    filename: Optional[str] = None,
+) -> str:
     """
     Seek to `timestamp` seconds in the video and save one frame as PNG.
     Returns the absolute path to the PNG.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    out_path = output_dir / f"{uuid.uuid4().hex}.png"
+    if filename is None:
+        fallback_id = stable_asset_id(f"file:{Path(video_path).resolve()}")
+        filename = keyframe_name(fallback_id, timestamp)
+    out_path = output_dir / filename
     cmd = [
         "ffmpeg", "-hide_banner", "-loglevel", "error",
         "-ss", str(timestamp),
         "-i", video_path,
         "-vframes", "1",
         "-q:v", "2",
-        str(out_path),
+        "-y", str(out_path),
     ]
     subprocess.run(cmd, check=True, timeout=60)
     return str(out_path)
@@ -181,12 +191,23 @@ def extract_scenes(
     scenes: list[Scene] = []
 
     for start, end in pairs:
+        stable_scene_id = scene_id(
+            asset.asset_id,
+            start,
+            end,
+            media_version=asset.checksum,
+        )
         kf_ts = start + (end - start) * _KEYFRAME_OFFSET
         keyframe_paths: list[str] = []
         quality: dict = {}
 
         try:
-            kf_path = extract_keyframe(asset.path, kf_ts, keyframe_dir)
+            kf_path = extract_keyframe(
+                asset.path,
+                kf_ts,
+                keyframe_dir,
+                filename=keyframe_name(stable_scene_id, kf_ts),
+            )
             keyframe_paths = [kf_path]
             quality = _quality_signals(kf_path)
         except Exception:
@@ -202,7 +223,7 @@ def extract_scenes(
                 pass
 
         scenes.append(Scene(
-            scene_id=str(uuid.uuid4()),
+            scene_id=stable_scene_id,
             asset_id=asset.asset_id,
             start_time=start,
             end_time=end,

--- a/scripts/content_creator_v2/stable_ids.py
+++ b/scripts/content_creator_v2/stable_ids.py
@@ -1,0 +1,69 @@
+"""Deterministic identifiers for Content Creator V2 assets and scenes.
+
+Identity is derived from source identity and media boundaries. It must never
+depend on wall-clock time, process state, or randomness because reruns need to
+update the same catalog rows and preserve human corrections.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+_ALGORITHM_VERSION = "v1"
+
+
+def _digest(namespace: str, *parts: str, length: int = 32) -> str:
+    payload = "\x1f".join((_ALGORITHM_VERSION, namespace, *parts))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:length]
+
+
+def _milliseconds(seconds: float) -> int:
+    if seconds is None:
+        raise ValueError("timestamp is required")
+    value = float(seconds)
+    if value < 0:
+        raise ValueError(f"timestamp cannot be negative: {seconds}")
+    return int(round(value * 1000))
+
+
+def asset_id(source_key: str) -> str:
+    """Return a stable ID for a source asset.
+
+    ``source_key`` is the source system's durable identity. The folder indexer
+    uses the resolved file path; a Photos adapter should pass the Photos UUID.
+    Media content/version deliberately does not change the parent identity.
+    """
+    if not source_key:
+        raise ValueError("source_key is required")
+    return "A-" + _digest("asset", source_key)
+
+
+def scene_id(
+    parent_asset_id: str,
+    start_seconds: float,
+    end_seconds: float,
+    *,
+    media_version: str,
+) -> str:
+    """Return a stable ID for one scene in one version of an asset."""
+    if not parent_asset_id:
+        raise ValueError("parent_asset_id is required")
+    if not media_version:
+        raise ValueError("media_version is required")
+    start_ms = _milliseconds(start_seconds)
+    end_ms = _milliseconds(end_seconds)
+    if end_ms <= start_ms:
+        raise ValueError(
+            f"scene end ({end_ms}ms) must be after start ({start_ms}ms)"
+        )
+    return "S-" + _digest(
+        "scene", parent_asset_id, media_version, str(start_ms), str(end_ms)
+    )
+
+
+def keyframe_name(parent_scene_id: str, timestamp_seconds: float) -> str:
+    """Return a deterministic, filesystem-safe PNG filename."""
+    if not parent_scene_id:
+        raise ValueError("parent_scene_id is required")
+    return f"{parent_scene_id}_{_milliseconds(timestamp_seconds)}.png"

--- a/scripts/tests/test_content_creator_v2_stable_ids.py
+++ b/scripts/tests/test_content_creator_v2_stable_ids.py
@@ -1,0 +1,153 @@
+"""Deterministic identity and rerun tests for Content Creator V2.
+
+Run:
+  python3 -m unittest scripts/tests/test_content_creator_v2_stable_ids.py
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO))
+
+from scripts.content_creator_v2 import ffprobe, scene_extractor  # noqa: E402
+from scripts.content_creator_v2.catalog import Catalog  # noqa: E402
+from scripts.content_creator_v2.contracts import MediaAsset  # noqa: E402
+from scripts.content_creator_v2.stable_ids import (  # noqa: E402
+    asset_id,
+    keyframe_name,
+    scene_id,
+)
+
+
+def _asset(*, checksum: str = "checksum-v1") -> MediaAsset:
+    return MediaAsset(
+        asset_id=asset_id("photos:ABC-123"),
+        path="/tmp/example.mov",
+        source="personal",
+        owner="mike",
+        captured_at=None,
+        duration=5.0,
+        width=1920,
+        height=1080,
+        orientation="landscape",
+        checksum=checksum,
+    )
+
+
+class StableIdUnitTests(unittest.TestCase):
+    def test_asset_id_is_stable_and_source_specific(self):
+        self.assertEqual(asset_id("photos:1"), asset_id("photos:1"))
+        self.assertNotEqual(asset_id("photos:1"), asset_id("photos:2"))
+
+    def test_scene_id_canonicalises_float_noise(self):
+        parent = asset_id("photos:1")
+        self.assertEqual(
+            scene_id(parent, 0.1 + 0.2, 3.0, media_version="v1"),
+            scene_id(parent, 0.3, 3.0, media_version="v1"),
+        )
+
+    def test_scene_id_changes_for_media_version_or_boundaries(self):
+        parent = asset_id("photos:1")
+        base = scene_id(parent, 0.0, 3.0, media_version="v1")
+        self.assertNotEqual(base, scene_id(parent, 0.0, 3.0, media_version="v2"))
+        self.assertNotEqual(base, scene_id(parent, 0.0, 4.0, media_version="v1"))
+
+    def test_invalid_identity_inputs_fail_loudly(self):
+        with self.assertRaises(ValueError):
+            asset_id("")
+        with self.assertRaises(ValueError):
+            scene_id("asset", 2.0, 2.0, media_version="v1")
+        with self.assertRaises(ValueError):
+            scene_id("asset", 0.0, 2.0, media_version="")
+
+    def test_keyframe_name_is_stable_and_safe(self):
+        sid = scene_id(asset_id("photos:1"), 0.0, 3.0, media_version="v1")
+        name = keyframe_name(sid, 0.6)
+        self.assertEqual(name, keyframe_name(sid, 0.6))
+        self.assertTrue(name.endswith(".png"))
+        for unsafe in ("/", "\\", ":", " ", "\x00"):
+            self.assertNotIn(unsafe, name)
+
+
+class FfprobeIdentityTests(unittest.TestCase):
+    def test_repeated_extract_uses_same_asset_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "clip.mov"
+            path.write_bytes(b"test")
+            probe = {
+                "format": {"duration": "2", "tags": {}},
+                "streams": [{"codec_type": "video", "width": 10, "height": 20}],
+            }
+            with patch.object(ffprobe, "_run_ffprobe", return_value=probe):
+                first = ffprobe.extract(path)
+                second = ffprobe.extract(path)
+        self.assertEqual(first.asset_id, second.asset_id)
+
+    def test_caller_supplied_source_id_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "clip.mov"
+            path.write_bytes(b"test")
+            probe = {"format": {"tags": {}}, "streams": []}
+            with patch.object(ffprobe, "_run_ffprobe", return_value=probe):
+                result = ffprobe.extract(path, asset_id="photos-stable-id")
+        self.assertEqual(result.asset_id, "photos-stable-id")
+
+
+class SceneExtractionRerunTests(unittest.TestCase):
+    def _run(self, asset: MediaAsset, output_dir: Path):
+        def fake_keyframe(_path, _timestamp, directory, *, filename=None):
+            return str(directory / filename)
+
+        with (
+            patch.object(scene_extractor, "detect_scenes", return_value=[(0.0, 2.0), (2.0, 5.0)]),
+            patch.object(scene_extractor, "extract_keyframe", side_effect=fake_keyframe),
+            patch.object(scene_extractor, "_quality_signals", return_value={}),
+        ):
+            return scene_extractor.extract_scenes(asset, output_dir)
+
+    def test_two_runs_produce_identical_scene_ids_and_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = self._run(_asset(), Path(tmp))
+            second = self._run(_asset(), Path(tmp))
+        self.assertEqual([s.scene_id for s in first], [s.scene_id for s in second])
+        self.assertEqual(
+            [s.keyframe_paths for s in first],
+            [s.keyframe_paths for s in second],
+        )
+
+    def test_changed_media_version_changes_scene_ids(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = self._run(_asset(checksum="v1"), Path(tmp))
+            second = self._run(_asset(checksum="v2"), Path(tmp))
+        self.assertNotEqual([s.scene_id for s in first], [s.scene_id for s in second])
+
+    def test_rerun_upserts_instead_of_duplicating_scenes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            asset = _asset()
+            scenes = self._run(asset, Path(tmp))
+            with Catalog(Path(tmp) / "catalog.db") as catalog:
+                catalog.upsert_asset(asset)
+                for scene in scenes:
+                    catalog.upsert_scene(scene)
+                for scene in self._run(asset, Path(tmp)):
+                    catalog.upsert_scene(scene)
+                self.assertEqual(catalog.stats(), {"assets": 1, "scenes": 2})
+
+
+class RandomIdentityRegressionTest(unittest.TestCase):
+    def test_identity_paths_no_longer_call_uuid4(self):
+        """CATCHES: random IDs reintroduced into asset or scene creation."""
+        self.assertNotIn("uuid.uuid4", inspect.getsource(ffprobe))
+        self.assertNotIn("uuid.uuid4", inspect.getsource(scene_extractor))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
Content Creator V2 still minted random `uuid4()` IDs for assets, scenes, and keyframes on current `main`. That makes reruns create new identities, breaks scene upsert/dedup behavior, and prevents human corrections from surviving a re-index.

## What changed
- deterministic asset IDs from durable source identity
- deterministic scene IDs from asset ID + media version + canonical millisecond boundaries
- deterministic keyframe filenames
- 11 regression/integration tests proving reruns keep identical IDs/paths and upsert instead of duplicate
- explicit regression check that `uuid.uuid4` is not reintroduced in these identity paths

## Provenance / collision safety
This is a clean re-application of the previously reviewed `fix/content-creator-v2-stable-ids` patch onto current `main`; the old branch had fallen 26 commits behind. The old branch was not rebased and no active shared working tree was touched. PR #243 was opened accidentally against the stale branch and immediately closed; this PR is the clean replacement.

## Scope
Exactly four files under `scripts/content_creator_v2` / `scripts/tests`. No routing, workflow, Remotion, or photo-library storage changes.

## Validation
The same implementation previously passed 11/11 targeted tests. This PR is intentionally re-run through today's repository quality gate before any merge decision.