### PR TITLE
docs: record the one manual setting still blocking the bot route

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -72,7 +72,53 @@ Three workflows push straight to `main` via `secrets.GITHUB_TOKEN`:
 | `ads_pulse.yml` | Mondays 08:00 ET | `docs/dashboard/*.html` |
 | `ads_approval_watcher.yml` | every 6h | `.github/agent_state/ads_api_approved.json` (only on state change) |
 
-### ✅ RESOLVED (PR #239) — the bots pass through the gate, nobody bypasses it
+### 🔴 ONE MANUAL SETTING IS STILL REQUIRED — the bots fail until you flip it
+
+Everything below is built, merged and tested. It does **not yet work end to end**,
+for one reason found by the self-test:
+
+```
+pull request create failed: GraphQL:
+GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
+```
+
+`repos/priihigashi/oak-park-ai-hub/actions/permissions/workflow` currently reports
+`can_approve_pull_request_reviews: false`. That toggle also governs *creating*
+PRs, so the helper cannot open one from inside a runner. Fix it with either:
+
+```bash
+gh api -X PUT repos/priihigashi/oak-park-ai-hub/actions/permissions/workflow \
+  -F default_workflow_permissions=write \
+  -F can_approve_pull_request_reviews=true
+```
+
+or the UI: **Settings → Actions → General → Workflow permissions →
+"Allow GitHub Actions to create and approve pull requests"**.
+
+Then prove it, don't assume it:
+
+```bash
+gh workflow run bot_route_selftest.yml
+gh run watch "$(gh run list --workflow=bot_route_selftest.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+A green run means a real commit reached `main` through the gate using
+`GITHUB_TOKEN`. Delete `bot_route_selftest.yml` after it passes once.
+
+**Until that setting is flipped, all three bots fail** — loudly, which is the
+correct behaviour and a deliberate change (the false all-clear was fixed in
+#239). `nonnegotiables.yml` is the first to hit it, at 02:00 ET.
+
+If you want them working before you get to this, the temporary fallback is to
+disable the ruleset — never to add a bypass actor:
+
+```bash
+gh api -X PUT repos/priihigashi/oak-park-ai-hub/rulesets/20720805 -f enforcement=disabled
+```
+
+---
+
+### ✅ The design (PR #239, corrected in #241) — bots pass through the gate
 
 The write-role bypass was **rejected as a solution**: it would exempt every human
 writer as well, in a repo where agent sessions hold write and admin tokens — the

--- a/.github/workflows/bot_route_selftest.yml
+++ b/.github/workflows/bot_route_selftest.yml
@@ -7,6 +7,14 @@
 #
 # Writes a timestamp to .github/agent_state/bot_route_selftest.txt and lands it
 # on main through the PR route. DELETE THIS WORKFLOW once it has passed once.
+#
+# STATUS 2026-08-11: run 31545374515 FAILED, and correctly so —
+#   "GitHub Actions is not permitted to create or approve pull requests"
+# The repo has can_approve_pull_request_reviews: false, which also blocks PR
+# CREATION from a runner. Enable it first:
+#   gh api -X PUT repos/priihigashi/oak-park-ai-hub/actions/permissions/workflow \
+#     -F default_workflow_permissions=write -F can_approve_pull_request_reviews=true
+# then re-run this workflow. See .github/rulesets/README.md.
 name: Bot Route Self-Test (temporary)
 
 on:


### PR DESCRIPTION
The in-runner self-test **failed**, which is exactly what it was built to catch.

The earlier laptop test used a personal admin token — a weaker claim. `GITHUB_TOKEN` is a different principal, and run `31545374515` hit:

```
pull request create failed: GraphQL:
GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

`actions/permissions/workflow` reports `can_approve_pull_request_reviews: false`, and that toggle governs PR **creation** too. Flipping it from this session was denied by the permission classifier, so it is documented with the exact command and UI path rather than left as a surprise.

Until it is flipped, all three bots fail — **loudly**, which is the corrected behaviour from #239, not a new regression. `nonnegotiables.yml` hits it first at 02:00 ET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)