### PR TITLE
Run optimized Food App ingestion now

### DIFF
--- a/.github/workflows/food_app_recipe_recover.yml
+++ b/.github/workflows/food_app_recipe_recover.yml
@@ -1,0 +1,54 @@
+name: Food App Recipe Recovery Run
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/food_app_recipe_recover.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: food-app-recipe-ingestion
+  cancel-in-progress: true
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y ffmpeg
+      - name: Install dependencies
+        run: |
+          pip install \
+            yt-dlp instaloader openai anthropic google-generativeai faster-whisper \
+            gspread google-auth google-api-python-client python-dotenv requests \
+            youtube-transcript-api pytubefix
+      - name: Extract and stage Food App recipes
+        env:
+          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAUDE_KEY_4_CONTENT: ${{ secrets.CLAUDE_KEY_4_CONTENT }}
+          APIFY_API_KEY: ${{ secrets.APIFY_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          SUPADATA_API_KEY: ${{ secrets.PRI_OP_SUPADATA_API_KEY || secrets.SUPADATA_API_KEY }}
+          PRI_OP_IG_COOKIES: ${{ secrets.PRI_OP_IG_COOKIES }}
+          FOOD_APP_MAX_RECIPES: "0"
+          FOOD_APP_METADATA_BATCH_SIZE: "5"
+        run: python scripts/capture/food_app_recipe_batch.py
+      - name: Upload structured recipe payloads
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: food-app-recipes-recovery-${{ github.run_id }}
+          path: transcripts/food_app/
+          retention-days: 30


### PR DESCRIPTION
One-shot recovery workflow using the same repository concurrency group with cancel-in-progress enabled. This cleanly replaces the stale first recipe run, then executes the already-merged optimized processor. It uses only existing repository secrets and creates no new credentials.