### PR TITLE
Use reliable Pages deployment for Food App review

### DIFF
--- a/.github/workflows/pages-food-app-release.yml
+++ b/.github/workflows/pages-food-app-release.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages-food-app-release.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload /docs site
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Deployment-only fix. The legacy branch-source Pages build for the already-audited Food App review is stuck in `building` with no reported error. This adds GitHub's supported Pages artifact/deploy workflow from `main`, uploading the existing entire `/docs` tree so other Pages content is preserved. It does not alter Food App HTML, recipes, images, or existing live ChatGPT-site app.