### PR TITLE
Extend Inspiration Library canonical schema

### DIFF
--- a/PIPELINE_REGISTRY.md
+++ b/PIPELINE_REGISTRY.md
@@ -1,8 +1,36 @@
 # Pipeline Registry — Single Source of Truth
-# oak-park-ai-hub · updated 2026-05-01
+# oak-park-ai-hub · updated 2026-08-18
 # Every template, format, and pipeline stage is listed here.
 # Before adding a new template or format: add a row here first.
 # Before running the pipeline: verify the template key matches an ACTIVE row.
+
+---
+
+## INSPIRATION REFERENCE GOVERNANCE — 2026-08-18
+
+Canonical searchable reference index:
+- Spreadsheet: **Ideas & Inbox** `1IrFrCNGVIF7cvAr9cIuAXvCtUR_-eQN1mdCpHXpfbcU`
+- Tab: **📥 Inspiration Library** (sheetId `1694604172`)
+
+Processing intake:
+- **📲 Capture Queue** (sheetId `124307869`)
+
+These are complementary:
+- Capture Queue = work needing media processing, transcription, frame/audio/duration/creator verification.
+- Inspiration Library = durable searchable index of references Priscila intentionally wants available for reuse.
+- A reference may be present in both. Never force a template/design/audio reference into only the processing queue.
+
+When the user identifies a URL as template/design/visual/font/typography/sound/audio/caption/motion/editing inspiration, upsert the normalized URL into Inspiration Library immediately. Preserve the user's raw reason for liking it. If analysis is still needed, also queue capture work; when processing finishes, enrich the same Inspiration Library row rather than appending a duplicate.
+
+Reusable-reference fields:
+`Visual Template?`, `Font / Typography?`, `Sound / Audio?`, `Caption Style?`, `Motion / Editing?`, `Duration Bucket`, `Exact Duration (sec)`, `Best Placement`, `Style Tags`, `Template Scope`, `Reference Status`, `Track Creator / Account?`.
+
+The five inspiration-type fields are independent Yes/No/Unknown values. Do not guess exact duration, creator/account, font name or audio title when inaccessible.
+
+Reference lifecycle:
+`Link only` → `Needs frame capture` → `Frames captured` → `Analyzed` → `Template built`.
+
+Drive stores screenshots, extracted frames, transcripts/audio references and built template assets. Inspiration Library is the index future content/template agents search before creating a new treatment.
 
 ---
 
@@ -39,6 +67,8 @@
 4. Named person on any slide → face required (bio-card or sticker-slot).
    No face = reviewer flags HIGH.
 
+5. Before inventing a new visual/editing treatment, search 📥 Inspiration Library for relevant saved references. A saved reference does not become a new FORMAT unless it is analyzed and genuinely reusable as a production structure.
+
 ---
 
 ## POST-READY CHECKLIST (reviewer enforces all)
@@ -55,6 +85,11 @@ A carousel is POST-READY only when:
 ---
 
 ## PIPELINE STAGE MAP
+
+stage 0 — inspiration/reference intake
+  /capture or the active content agent detects user-stated template/design/font/sound/caption/motion inspiration
+  Normalize/dedupe source URL → upsert 📥 Inspiration Library immediately
+  If screenshots/transcript/audio/duration/creator analysis is needed → also add/keep 📲 Capture Queue
 
 stage 1 — topic_picker.py
   Reads Inspiration Library + Content Queue
@@ -79,6 +114,7 @@ stage 4 — main.py upload
   Upload png/ + motion/ + resources/ + caption.txt to Drive version folder
   Create story Google Doc in Drive
   write_inspo_status() — update Inspiration Library row
+  If an inspiration reference produced a durable reusable implementation, link the output back to the same row and advance Reference Status only to the achieved state
 
 stage 5 — email_preview.py
   Send preview email with Drive link + thumbnail + caption
@@ -94,9 +130,11 @@ None identified yet. Add here when a template is retired.
 
 ## ADDING A NEW TEMPLATE
 
-1. Add a row to ACTIVE TEMPLATES above
-2. Add the builder function to carousel_builder.py
-3. Add routing to generate_carousel_content() and build_html()
-4. Add reviewer checks if the template has unique structural rules
-5. Add a row to the Templates Registry tab in Spreadsheet Hub (1qDbO6JQX0cKbZ9rHjiM7a4U_p7OOddZ3k3Sp30JJoqo)
-6. Test with a manual run before enabling in the daily pipeline
+1. Search 📥 Inspiration Library and existing template assets first; reuse/extend when appropriate.
+2. Add a row to ACTIVE TEMPLATES above.
+3. Add the builder function to carousel_builder.py.
+4. Add routing to generate_carousel_content() and build_html().
+5. Add reviewer checks if the template has unique structural rules.
+6. Add a row to the Templates Registry tab in Spreadsheet Hub (1qDbO6JQX0cKbZ9rHjiM7a4U_p7OOddZ3k3Sp30JJoqo).
+7. Test with a manual run before enabling in the daily pipeline.
+8. If the template came from a saved Inspiration Library reference, link the durable implementation back to that row and set `Reference Status = Template built` only after the implementation exists.

--- a/scripts/lib/sheet_schema.py
+++ b/scripts/lib/sheet_schema.py
@@ -14,40 +14,67 @@ Usage:
 """
 
 # ── Inspiration Library (📥 Inspiration Library) ─────────────────────────────
-# Canonical schema as of 2026-04-17 remap (29 columns A–AC)
+# Canonical schema as of 2026-08-18 (46 columns A–AT).
+# A–AH are legacy/content-pipeline fields; AI–AT are the reusable-inspiration
+# taxonomy added 2026-08-18. Scripts MUST resolve by header name at runtime so
+# future column moves/additions do not silently corrupt data.
 INSPO_COLS = {
-    "date_added":           "date added",          # A
-    "content_hub_link":     "content hub link",    # B  ← moved here 2026-04-17
-    "platform":             "platform",             # C
-    "url":                  "url",                  # D
-    "creator":              "creator / account",   # E
-    "content_type":         "content type",         # F
-    "description":          "description",          # G
-    "transcription":        "transcription",        # H
-    "original_caption":     "original caption",    # I
-    "visual_hook":          "visual hook",          # J
-    "hook_type":            "hook type",            # K
-    "views":                "views",                # L
-    "comments":             "engagement comments", # M
-    "saves_shares":         "saves / shares",      # N
-    "whats_working":        "what's working",      # O
-    "ab_test":              "a/b test",             # P
-    "brief_angle":          "brief / angle",       # Q
-    "format":               "format",               # R
-    "status":               "status",               # S
-    "topic_title":          "topic / title",        # T
-    "niche":                "niche",                # U
-    "my_comments":          "comments",             # V
-    "ai_score":             "ai score (1-5)",      # W
-    "date_status_changed":  "date status changed", # X
-    "drive_folder_path":    "drive folder path",   # Y
-    "my_raw_notes":         "my raw notes",        # Z
-    "series_override":      "series_override",     # AA
-    "fake_news_route":      "fake_news_route",     # AB
-    "fake_news_confidence": "fake_news_confidence",# AC
-    "credibility":          "credibility",          # AD
-    "manifest_url":         "manifest_url",         # AE
-    "sibling_of":           "sibling_of",          # AG (AF=STATUS exists, AG=new)
+    "date_added":            "date added",              # A
+    "content_hub_link":      "content hub link",        # B
+    "platform":              "platform",                # C
+    "url":                   "url",                     # D
+    "creator":               "creator / account",       # E
+    "content_type":          "content type",            # F
+    "description":           "description",             # G
+    "transcription":         "transcription",           # H
+    "original_caption":      "original caption",        # I
+    "visual_hook":           "visual hook",             # J
+    "hook_type":             "hook type",               # K
+    "views":                 "views",                   # L
+    "comments":              "engagement comments",     # M
+    "saves_shares":          "saves / shares",          # N
+    "whats_working":         "what's working",          # O
+    "ab_test":               "a/b test",                # P
+    "brief_angle":           "brief / angle",           # Q
+    "format":                "format",                  # R
+    "status":                "status",                  # S
+    "topic_title":           "topic / title",           # T
+    "niche":                 "niche",                   # U
+    "my_comments":           "comments",                # V
+    "ai_score":              "ai score (1-5)",          # W
+    "date_status_changed":   "date status changed",     # X
+    "drive_folder_path":     "drive folder path",       # Y
+    "my_raw_notes":          "my raw notes",            # Z
+    "series_override":       "series_override",         # AA
+    "fake_news_route":       "fake_news_route",         # AB
+    "fake_news_confidence":  "fake_news_confidence",    # AC
+    "credibility":           "credibility",             # AD
+    "manifest_url":          "manifest_url",            # AE
+    "pipeline_status":       "status",                  # AF — duplicate legacy header
+    "sibling_of":            "sibling_of",              # AG
+    "story_id":              "story_id",                # AH
+    # Reusable-reference taxonomy — 2026-08-18
+    "visual_template":       "visual template?",        # AI
+    "font_typography":       "font / typography?",      # AJ
+    "sound_audio":           "sound / audio?",          # AK
+    "caption_style":         "caption style?",          # AL
+    "motion_editing":        "motion / editing?",       # AM
+    "duration_bucket":       "duration bucket",         # AN
+    "exact_duration_sec":    "exact duration (sec)",     # AO
+    "best_placement":        "best placement",           # AP
+    "style_tags":            "style tags",               # AQ
+    "template_scope":        "template scope",           # AR
+    "reference_status":      "reference status",         # AS
+    "track_creator_account": "track creator / account?", # AT
+}
+
+# Reusable-reference enums. Keep these aligned with the live sheet validation.
+INSPO_TRI_STATE = {"yes", "no", "unknown"}
+INSPO_DURATION_BUCKETS = {"≤15s", "16–30s", "31–60s", "61–180s", ">180s", "Unknown"}
+INSPO_BEST_PLACEMENT = {"Full short", "Intro", "Mid-video impact", "Outro", "Flexible"}
+INSPO_TEMPLATE_SCOPE = {"Universal", "News", "OPC", "UGC", "Multiple"}
+INSPO_REFERENCE_STATUS = {
+    "Link only", "Needs frame capture", "Frames captured", "Analyzed", "Template built"
 }
 
 # Valid status values for Inspiration Library Status column
@@ -64,7 +91,7 @@ CONTENT_QUEUE_COLS = {
     "photos_used":        "photo(s) used",         # D
     "content_type":       "content type",           # E
     "hook":               "hook",                   # F
-    "caption_body":       "caption body",          # G
+    "caption_body":       "caption body",           # G
     "cta":                "cta",                    # H
     "hashtags":           "hashtags",               # I
     "date_status_changed":"date status changed",   # J
@@ -82,14 +109,14 @@ CAPTURE_QUEUE_COLS = {
     "moved_to":          "moved to",               # F
     "hub_doc_path":      "hub doc path",           # G
     "project":           "project",                # H
-    "credits_source":    "credits/source",         # I  (added 2026-04-17 by ux-agent)
+    "credits_source":    "credits/source",         # I
     "content_ideas":     "content ideas generated",# J
     "ready_to_build":    "ready to build",         # K
-    "cut_windows":       "cut_windows",            # L — existing (not added by SH-105)
-    "screenshots":       "screenshots",            # M — existing (not added by SH-105)
-    "failed_at_stage":   "failed_at_stage",        # N — SH-105: capture stage that failed
-    "resume_folder_id":  "resume_folder_id",       # O — SH-105: Drive folder with partial work
-    "failed_at_ts":      "failed_at_timestamp",    # P — SH-105: ISO UTC timestamp of failure
+    "cut_windows":       "cut_windows",            # L
+    "screenshots":       "screenshots",            # M
+    "failed_at_stage":   "failed_at_stage",        # N
+    "resume_folder_id":  "resume_folder_id",       # O
+    "failed_at_ts":      "failed_at_timestamp",    # P
 }
 
 # ── Helper ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- Updates `scripts/lib/sheet_schema.py` to match the live `📥 Inspiration Library` schema through column AT.
- Adds the 2026-08-18 reusable-reference fields for visual, typography, sound, caption, motion, duration, placement, style tags, scope, reference status, and creator tracking.
- Adds canonical enum constants for the new filter values.
- Keeps header-name runtime lookup as the safety mechanism so scripts do not depend on fixed column positions.

## Why
The live Ideas & Inbox Inspiration Library was expanded into the canonical searchable template/design/audio inspiration index. The repository schema still described the older A–AC layout, which could cause future agents/scripts to ignore the new fields or make unsafe assumptions.

## Impact
Capture/content tooling can now reference the new Inspiration Library taxonomy from one code-level source of truth. This does not change existing pipeline fields or remove legacy columns.

## Validation
Compared the mapping against the live Google Sheet headers A:AT after the 2026-08-18 schema update.